### PR TITLE
LPS-21267 Workflow loses ServiceContext

### DIFF
--- a/webs/kaleo-web/docroot/WEB-INF/src/com/liferay/portal/workflow/kaleo/WorkflowInstanceManagerImpl.java
+++ b/webs/kaleo-web/docroot/WEB-INF/src/com/liferay/portal/workflow/kaleo/WorkflowInstanceManagerImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.workflow.kaleo;
 
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowException;
 import com.liferay.portal.kernel.workflow.WorkflowInstance;
 import com.liferay.portal.kernel.workflow.WorkflowInstanceManager;
@@ -207,7 +208,8 @@ public class WorkflowInstanceManagerImpl implements WorkflowInstanceManager {
 			String transitionName, Map<String, Serializable> workflowContext)
 		throws WorkflowException {
 
-		ServiceContext serviceContext = new ServiceContext();
+		ServiceContext serviceContext = (ServiceContext)workflowContext.get(
+			WorkflowConstants.CONTEXT_SERVICE_CONTEXT);
 
 		serviceContext.setCompanyId(companyId);
 		serviceContext.setScopeGroupId(groupId);


### PR DESCRIPTION
This causes all workflow operations invoked by a remote operation (webdav or webservice call) that include a ServiceContext parameter to fail.
