### PR TITLE
LPS-22758

### DIFF
--- a/portlets/mail-portlet/docroot/view_messages.jsp
+++ b/portlets/mail-portlet/docroot/view_messages.jsp
@@ -212,7 +212,7 @@ MailManager mailManager = MailManager.getInstance(request);
 
 						<tr class="<%= rowCssClass %>">
 							<td>
-								<aui:input id="message<%= message.getMessageId() %>" label="" messageId="<%= message.getMessageId() %>" name="message" type="checkbox" value="<%= message.getMessageId() %>" />
+								<aui:input id="<%= "message" + message.getMessageId() %>" label="" messageId="<%= message.getMessageId() %>" name="message" type="checkbox" value="<%= message.getMessageId() %>" />
 							</td>
 							<td>
 								<div class="<%= messageCssClass %>" data-folderId="<%= folderId %>" data-keywords="<%= keywords %>" data-messageId="<%= message.getMessageId() %>" data-messageNumber="<%= messageNumber %>" data-orderByField="<%= orderByField %>" data-orderByType="<%= orderByType %>">


### PR DESCRIPTION
Error occurs due to JSP compilation error in Resin that disallows us from having part of a value be outside of <%= %> and part of it inside <%= %>. To resolve it, put everything inside of <%= %>.
