### PR TITLE
LPS-22843 Fix Source Formating

### DIFF
--- a/hooks/sample-application-adapter-hook/docroot/META-INF/custom_jsps/html/portlet/navigation/view.jsp
+++ b/hooks/sample-application-adapter-hook/docroot/META-INF/custom_jsps/html/portlet/navigation/view.jsp
@@ -14,7 +14,9 @@
  */
 --%>
 
-<liferay-util:include page="/html/portlet/navigation/view.portal.jsp" />
+<%@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
+
+<liferay-util:include page="/html/portlet/navigation/view.jsp" useCustomPage="false"  />
 
 <p>
 	This was modified by the Sample Application Adapter.


### PR DESCRIPTION
Hey Brian, 

in the application adapters, we don't create the *.portal.jsp (because there may be many application adapters)

http://www.liferay.com/es/community/wiki/-/wiki/Main/Application+Adapters
