### PR TITLE
LPS-26394

### DIFF
--- a/portlets/logos-reftagger-portlet/docroot/view.jsp
+++ b/portlets/logos-reftagger-portlet/docroot/view.jsp
@@ -19,12 +19,11 @@
 
 <liferay-util:html-bottom>
 	<script src="http://bible.logos.com/jsapi/referencetagging.js" type="text/javascript"></script>
+	<aui:script position="inline">
+		Logos.ReferenceTagging.lbsBibleVersion = "ESV";
+		Logos.ReferenceTagging.lbsLinksOpenNewWindow = true;
+		Logos.ReferenceTagging.lbsLibronixLinkIcon = "dark";
+		Logos.ReferenceTagging.lbsNoSearchTagNames = [ "h1", "h2", "h3" ];
+		Logos.ReferenceTagging.tag();
+	</aui:script>
 </liferay-util:html-bottom>
-
-<aui:script position="inline">
-	Logos.ReferenceTagging.lbsBibleVersion = "ESV";
-	Logos.ReferenceTagging.lbsLinksOpenNewWindow = true;
-	Logos.ReferenceTagging.lbsLibronixLinkIcon = "dark";
-	Logos.ReferenceTagging.lbsNoSearchTagNames = [ "h1", "h2", "h3" ];
-	Logos.ReferenceTagging.tag();
-</aui:script>


### PR DESCRIPTION
The source formatting from LPS-10529 causes the content of the aui:script tag to appear before the <script src="..."> tag in the final page.
