### PR TITLE
LPS-27209 plugin webapps folder not removed during undeploy

### DIFF
--- a/hooks/so-hook/docroot/META-INF/context.xml
+++ b/hooks/so-hook/docroot/META-INF/context.xml
@@ -1,2 +1,0 @@
-<Context>
-</Context>

--- a/portlets/so-portlet/docroot/META-INF/context.xml
+++ b/portlets/so-portlet/docroot/META-INF/context.xml
@@ -1,2 +1,0 @@
-<Context>
-</Context>


### PR DESCRIPTION
I removed context.xml files from so-hook and so-portlet, so that default ones are copied during deployment, and allow removing folders during undeployment
