### PR TITLE
SOS-1135

### DIFF
--- a/portlets/contacts-portlet/docroot/WEB-INF/src/com/liferay/contacts/contactscenter/portlet/ContactsCenterPortlet.java
+++ b/portlets/contacts-portlet/docroot/WEB-INF/src/com/liferay/contacts/contactscenter/portlet/ContactsCenterPortlet.java
@@ -45,6 +45,7 @@ import com.liferay.portal.kernel.bean.BeanParamUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.notifications.ChannelHubManagerUtil;
 import com.liferay.portal.kernel.notifications.NotificationEvent;
 import com.liferay.portal.kernel.notifications.NotificationEventFactoryUtil;
@@ -52,6 +53,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletResponseUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -93,6 +95,7 @@ import java.util.List;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
+import javax.portlet.PortletConfig;
 import javax.portlet.PortletException;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
@@ -456,7 +459,7 @@ public class ContactsCenterPortlet extends MVCPortlet {
 			jsonObject.put("success", false);
 		}
 
-		jsonObject.put("message", themeDisplay.translate(message));
+		jsonObject.put("message", translate(actionRequest, message));
 
 		writeJSON(actionRequest, actionResponse, jsonObject);
 	}
@@ -562,7 +565,7 @@ public class ContactsCenterPortlet extends MVCPortlet {
 				message = "please-enter-a-valid-url";
 			}
 
-			jsonObject.put("message", themeDisplay.translate(message));
+			jsonObject.put("message", translate(actionRequest, message));
 
 			jsonObject.put("success", false);
 		}
@@ -647,7 +650,7 @@ public class ContactsCenterPortlet extends MVCPortlet {
 
 		String message = getRelationMessage(actionRequest);
 
-		jsonObject.put("message", themeDisplay.translate(message));
+		jsonObject.put("message", translate(actionRequest, message));
 
 		return jsonObject;
 	}
@@ -986,6 +989,17 @@ public class ContactsCenterPortlet extends MVCPortlet {
 		ChannelHubManagerUtil.sendNotificationEvent(
 			socialRequest.getCompanyId(), socialRequest.getReceiverUserId(),
 			notificationEvent);
+	}
+
+	protected String translate(PortletRequest portletRequest, String key) {
+		PortletConfig portletConfig =
+			(PortletConfig)portletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_CONFIG);
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		return LanguageUtil.get(portletConfig, themeDisplay.getLocale(), key);
 	}
 
 	protected void updateAdditionalEmailAddresses(ActionRequest actionRequest)

--- a/portlets/private-messaging-portlet/docroot/WEB-INF/src/com/liferay/privatemessaging/portlet/PrivateMessagingPortlet.java
+++ b/portlets/private-messaging-portlet/docroot/WEB-INF/src/com/liferay/privatemessaging/portlet/PrivateMessagingPortlet.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.io.ByteArrayFileInputStream;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.notifications.Channel;
@@ -33,6 +34,7 @@ import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -70,6 +72,7 @@ import java.util.List;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
+import javax.portlet.PortletConfig;
 import javax.portlet.PortletException;
 import javax.portlet.PortletRequest;
 import javax.portlet.ResourceRequest;
@@ -354,8 +357,8 @@ public class PrivateMessagingPortlet extends MVCPortlet {
 				fileMaxSize);
 		}
 		else if (key instanceof UserScreenNameException) {
-			message = themeDisplay.translate(
-				"the-following-users-were-not-found");
+			message = translate(
+				portletRequest, "the-following-users-were-not-found");
 
 			message += CharPool.SPACE + key.getMessage();
 		}
@@ -442,6 +445,17 @@ public class PrivateMessagingPortlet extends MVCPortlet {
 					companyId, userId, notificationEvent.getUuid());
 			}
 		}
+	}
+
+	protected String translate(PortletRequest portletRequest, String key) {
+		PortletConfig portletConfig =
+			(PortletConfig)portletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_CONFIG);
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		return LanguageUtil.get(portletConfig, themeDisplay.getLocale(), key);
 	}
 
 	protected void validateAttachment(String fileName, InputStream inputStream)


### PR DESCRIPTION
Hi Brian,

We need to use this method to translate the strings because when we make an Ajax request, the plugin is not able to find strings that are not part of the portal language.properties

Regards,

Eudaldo.
