### PR TITLE
LPS-17088

### DIFF
--- a/themes/7cogs-brochure-theme/docroot/WEB-INF/liferay-plugin-package.properties
+++ b/themes/7cogs-brochure-theme/docroot/WEB-INF/liferay-plugin-package.properties
@@ -10,5 +10,5 @@ licenses=LGPL
 liferay-versions=6.1.1
 
 required-deployment-contexts=\
-    1-3-1-columns-layouttpl,\
+    1-3-1-columns-layout-template,\
     resources-importer-web


### PR DESCRIPTION
The required dependencies name changed for layouts. I guess layouts now get deployed as 1-3-1-columns-layout-template compared to 1-3-1-columns-layouttpl
