### PR TITLE
SOS-1152

### DIFF
--- a/hooks/so-hook/docroot/WEB-INF/liferay-plugin-package.properties
+++ b/hooks/so-hook/docroot/WEB-INF/liferay-plugin-package.properties
@@ -16,6 +16,5 @@ required-deployment-contexts=\
     private-messaging-portlet,\
     so-portlet,\
     so-theme,\
-    so-welcome-theme,\
     tasks-portlet,\
     wysiwyg-portlet


### PR DESCRIPTION
Please backport to 6.1.x. so-welcome-theme is not a requirement, this will cause deadlock because so-welcome-theme requires so-hook
