### PR TITLE
LPS-28904 Test Portlet Title and Description translation

### DIFF
--- a/portlets/test-misc-portlet/docroot/WEB-INF/portlet.xml
+++ b/portlets/test-misc-portlet/docroot/WEB-INF/portlet.xml
@@ -13,6 +13,7 @@
 		<supports>
 			<mime-type>text/html</mime-type>
 		</supports>
+		<resource-bundle>content.Language</resource-bundle>
 		<portlet-info>
 			<title>Test Misc</title>
 			<short-title>Test Misc</short-title>

--- a/portlets/test-misc-portlet/docroot/WEB-INF/src/com/liferay/testmisc/localization/TestLocalizationUtil.java
+++ b/portlets/test-misc-portlet/docroot/WEB-INF/src/com/liferay/testmisc/localization/TestLocalizationUtil.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.testmisc.localization;
+
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.model.Portlet;
+import com.liferay.portal.theme.PortletDisplay;
+import com.liferay.portal.theme.ThemeDisplay;
+import com.liferay.portal.util.PortalUtil;
+
+import java.util.Locale;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Eduardo Garcia
+ */
+public class TestLocalizationUtil {
+
+	public static String getLocalizedPortletDescription(
+		HttpServletRequest request, ServletContext servletContext) {
+
+		Locale locale = new Locale("en", "US");
+
+		Portlet portlet = (Portlet)request.getAttribute(WebKeys.RENDER_PORTLET);
+
+		return PortalUtil.getPortletDescription(
+			portlet, servletContext, locale);
+	}
+
+	public static String getLocalizedPortletTitle(
+		HttpServletRequest request, ServletContext servletContext) {
+
+		Locale locale = new Locale("en", "US");
+		
+		Portlet portlet = (Portlet)request.getAttribute(WebKeys.RENDER_PORTLET);
+
+		return PortalUtil.getPortletTitle(portlet, servletContext, locale);
+	}
+	
+	public static String getPortletDisplayTitle(HttpServletRequest request) {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)request.getAttribute(WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		return portletDisplay.getTitle();
+	}
+	
+}

--- a/portlets/test-misc-portlet/docroot/WEB-INF/src/com/liferay/testmisc/portlet/TestPortlet.java
+++ b/portlets/test-misc-portlet/docroot/WEB-INF/src/com/liferay/testmisc/portlet/TestPortlet.java
@@ -54,6 +54,12 @@ public class TestPortlet extends LiferayPortlet {
 			RenderRequest renderRequest, RenderResponse renderResponse)
 		throws IOException, PortletException {
 
+		String title = ParamUtil.getString(renderRequest, "title");
+		
+		if (Validator.isNotNull(title)) {
+			renderResponse.setTitle(title);
+		}
+
 		String mvcPath = ParamUtil.getString(
 			renderRequest, "mvcPath", "/view.jsp");
 

--- a/portlets/test-misc-portlet/docroot/WEB-INF/src/content/Language_en.properties
+++ b/portlets/test-misc-portlet/docroot/WEB-INF/src/content/Language_en.properties
@@ -1,0 +1,2 @@
+javax.portlet.title.1_WAR_testmiscportlet=Test Misc Localized Title
+javax.portlet.description.1_WAR_testmiscportlet=Test Misc Localized Description

--- a/portlets/test-misc-portlet/docroot/init.jsp
+++ b/portlets/test-misc-portlet/docroot/init.jsp
@@ -20,6 +20,8 @@
 
 <%@ page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
+page import="com.liferay.portal.kernel.util.Validator" %><%@
+page import="com.liferay.testmisc.localization.TestLocalizationUtil" %><%@
 page import="com.liferay.testmisc.messaging.TestSchedulerMessageListener" %><%@
 page import="com.liferay.testmisc.scheduler.TestSchedulerUtil" %>
 

--- a/portlets/test-misc-portlet/docroot/view.jsp
+++ b/portlets/test-misc-portlet/docroot/view.jsp
@@ -16,6 +16,19 @@
 
 <%@ include file="/init.jsp" %>
 
+<%
+String defaultDescription = "Test Misc Localized Description";
+String defaultTitle = "Test Misc Localized Title";
+String title = ParamUtil.getString(renderRequest, "title", defaultTitle);
+%>
+
+<h3>Portlet Localized Title and Description</h3>
+
+<p>
+	TestLocalizationUtil.getLocalizedPortletTitle=<%= _assertEquals(TestLocalizationUtil.getLocalizedPortletTitle(request, application), defaultTitle) %><br />
+	TestLocalizationUtil.getLocalizedPortletDescription=<%= _assertEquals(TestLocalizationUtil.getLocalizedPortletDescription(request, application), defaultDescription) %><br />
+</p>
+
 <h3>Portlet Request</h3>
 
 <p>
@@ -40,6 +53,14 @@
 <p>
 	<a href="<portlet:renderURL><portlet:param name="mvcPath" value="/portlet_response/buffer_size.jsp" /></portlet:renderURL>">Buffer Size</a><br />
 	<a href="<portlet:resourceURL id="logo.png" />">Download File</a>
+</p>
+
+<h3>Portlet Response (Title)</h3>
+
+<p>
+	TestLocalizationUtil.getPortletDisplayTitle=<%= _assertEquals(TestLocalizationUtil.getPortletDisplayTitle(request), title) %><br /><br />
+	<a href="<portlet:renderURL><portlet:param name="title" value="New Title" /></portlet:renderURL>">Change Portlet Title</a><br />
+	<a href="<portlet:renderURL />">Restore Portlet Title</a>
 </p>
 
 <h3>Portlet Session</h3>
@@ -70,6 +91,10 @@
 </p>
 
 <%!
+private static String _assertEquals(Object expected, Object actual) {
+	return _assertTrue(Validator.equals(expected, actual));
+}
+	
 private static String _assertTrue(boolean value) {
 	if (value) {
 		return "PASSED";


### PR DESCRIPTION
I've extended test-misc-portlet including some tests to validate the latest changes in PortalUtil.getPortletTitle(), PortalUtil.getPortletDescription() and LiferayPortlet.getTitle() to support an extended format for portlet title and description localization, similar to the one we are using for portal portlets. 
