### PR TITLE
SOS-587 Only the createAccountURL must contain the member key in the redirect param. Do not change the order

### DIFF
--- a/portlets/so-portlet/docroot/WEB-INF/src/com/liferay/so/service/impl/MemberRequestLocalServiceImpl.java
+++ b/portlets/so-portlet/docroot/WEB-INF/src/com/liferay/so/service/impl/MemberRequestLocalServiceImpl.java
@@ -322,16 +322,6 @@ public class MemberRequestLocalServiceImpl
 			redirectURL = serviceContext.getCurrentURL();
 		}
 
-		String createAccountURL = (String)serviceContext.getAttribute(
-			"createAccountURL");
-
-		if (Validator.isNull(createAccountURL)) {
-			createAccountURL = serviceContext.getPortalURL();
-		}
-
-		createAccountURL = HttpUtil.addParameter(
-			createAccountURL, "redirect", redirectURL);
-
 		String loginURL = (String)serviceContext.getAttribute("loginURL");
 
 		if (Validator.isNull(loginURL)) {
@@ -340,8 +330,18 @@ public class MemberRequestLocalServiceImpl
 
 		loginURL = HttpUtil.addParameter(loginURL, "redirect", redirectURL);
 
+		String createAccountURL = (String)serviceContext.getAttribute(
+			"createAccountURL");
+
+		if (Validator.isNull(createAccountURL)) {
+			createAccountURL = serviceContext.getPortalURL();
+		}
+
 		redirectURL = HttpUtil.addParameter(
 			redirectURL, "key", memberRequest.getKey());
+
+		createAccountURL = HttpUtil.addParameter(
+			createAccountURL, "redirect", redirectURL);
 
 		body = StringUtil.replace(
 			body,


### PR DESCRIPTION
Hi Brian,

In your source formatting you changed the order in which the createAccountURL and loginURL are generated. Normally your order' would be fine, but in this case we need the loginURL to be created first with the redirect param still not containing the member key, and then the createAccountURL with the redirect param containing the member key.

This is important so that the LoginPostAction event in the portlet-hook creates a notification only for the new users (the existing ones, redirected to LoginURL, already have the notification created).

Thanks!
