### PR TITLE
LPS-30366 Mail attachments are not displayed or sent

### DIFF
--- a/portlets/mail-portlet/docroot/WEB-INF/src/com/liferay/mail/imap/IMAPAccessor.java
+++ b/portlets/mail-portlet/docroot/WEB-INF/src/com/liferay/mail/imap/IMAPAccessor.java
@@ -40,7 +40,6 @@ import com.liferay.util.mail.InternetAddressUtil;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 
 import java.util.ArrayList;
@@ -972,10 +971,7 @@ public class IMAPAccessor {
 		String fileName = part.getFileName();
 		Object content = part.getContent();
 
-		if (content instanceof InputStream) {
-			return;
-		}
-		else if (content instanceof Multipart) {
+		if (content instanceof Multipart) {
 			Multipart multipart = (Multipart)content;
 
 			for (int i = 0; i < multipart.getCount(); i++) {


### PR DESCRIPTION
Hi Brian,
this is actually a rollback for LPS-22761 because there was problem with jboss 7.0.x. We are now on 7.1.x, and the mentioned problem doesn't exists anymore.
