### PR TITLE
LPS-31936 Is it necessary to supply the resources importer's releng data...

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -181,6 +181,7 @@
 			/>
 			<zipfileset
 				dir="."
+				excludes="**/releng/"
 				includes="webs/resources-importer-web/**"
 				prefix="liferay-plugins-sdk-${lp.version}"
 			/>


### PR DESCRIPTION
... in the sdk? Currently makes up for 2/3 of the zip's size
