### PR TITLE
LPS-32149 Error when excluding more than one site in the chat portlet

### DIFF
--- a/portlets/chat-portlet/docroot/WEB-INF/src/com/liferay/chat/service/persistence/StatusFinderImpl.java
+++ b/portlets/chat-portlet/docroot/WEB-INF/src/com/liferay/chat/service/persistence/StatusFinderImpl.java
@@ -143,7 +143,7 @@ public class StatusFinderImpl
 			QueryPos qPos = QueryPos.getInstance(q);
 
 			qPos.add(userId);
-			qPos.add(groupNames);
+			qPos.add(StringUtil.merge(groupNames));
 			qPos.add(modifiedDate);
 			qPos.add(userId);
 


### PR DESCRIPTION
The method QueryPos#add(array) adds every element of the array as an individual positional parameter. To add all the elements as one only positional parameter (as for an IN clause) the elements must be first merged into a comma separated values string.
