### PR TITLE
SOS-985

### DIFF
--- a/build-common-plugin.xml
+++ b/build-common-plugin.xml
@@ -487,6 +487,9 @@
 				<not>
 					<available file="docroot/WEB-INF/lib/.svn" />
 				</not>
+				<length when="equal" length="0">
+					<fileset dir="docroot/WEB-INF/lib" erroronmissingdir="false" />
+				</length>
 			</and>
 			<then>
 				<delete dir="docroot/WEB-INF/lib" />


### PR DESCRIPTION
If you commit to SVN right after creating something and set it to "prune empty folders", it will not be version controlled.  If you then run build-service, the service JAR will be created in the lib folder, but until you commit the lib folder itself, you won't be able to do a "clean war" because the "clean" target clears out the lib folder due to it having been pruned in the first commit.
