### PR TITLE
LPS-36592 Adding necessary .jar files for ivy

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -190,7 +190,7 @@
 			/>
 			<zipfileset
 				dir="."
-				includes="lib/ant-contrib.jar,lib/antelopetasks.jar"
+				includes="lib/ant-contrib.jar,lib/antelopetasks.jar,lib/bcpg-jdk16.jar,lib/bcprov-jdk16.jar"
 				prefix="liferay-plugins-sdk-${lp.version}"
 			/>
 		</zip>


### PR DESCRIPTION
We would need this backported to make my plugin automation work from master to ee-6.1.20. It's also required for the extracted plugins sdk.

These jars are on Ivy's classpath so they are different from the other ones which are fetched by Ivy.

Thank you,
Zsolt
