### PR TITLE
LPS-40482

### DIFF
--- a/themes/build-common-theme.xml
+++ b/themes/build-common-theme.xml
@@ -125,13 +125,6 @@
 						/>
 					</copy>
 
-					<copy todir="docroot" overwrite="false" preservelastmodified="true">
-						<fileset
-							dir="${app.server.portal.dir}/html/themes/classic"
-							includes="**/.sass-cache/**"
-						/>
-					</copy>
-
 					<copy todir="docroot/templates" overwrite="true" preservelastmodified="true">
 						<fileset
 							dir="${app.server.portal.dir}/html/themes/classic/templates"
@@ -147,13 +140,6 @@
 						<fileset
 							dir="${app.server.portal.dir}/html/themes/control_panel"
 							excludes="**/.sass-cache/**,_diffs/**,templates/**"
-						/>
-					</copy>
-
-					<copy todir="docroot" overwrite="false" preservelastmodified="true">
-						<fileset
-							dir="${app.server.portal.dir}/html/themes/control_panel"
-							includes="**/.sass-cache/**"
 						/>
 					</copy>
 
@@ -174,13 +160,6 @@
 						<fileset
 							dir="${theme.parent}/docroot"
 							excludes="**/.sass-cache/**,_diffs/**,WEB-INF/*.properties,WEB-INF/*.xml"
-						/>
-					</copy>
-
-					<copy todir="docroot" overwrite="false" preservelastmodified="true">
-						<fileset
-							dir="${theme.parent}/docroot"
-							includes="**/.sass-cache/**"
 						/>
 					</copy>
 				</then>


### PR DESCRIPTION
Copying sass-cache from parent theme causes bad links.

ie: http://localhost:8080/welcome-theme/html/themes/classic/images/portlet/options_borderless.png
