### PR TITLE
SOS-1820

### DIFF
--- a/hooks/so-hook/docroot/WEB-INF/src/com/liferay/so/hook/upgrade/UpgradeProcess_2_0_4.java
+++ b/hooks/so-hook/docroot/WEB-INF/src/com/liferay/so/hook/upgrade/UpgradeProcess_2_0_4.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This file is part of Liferay Social Office. Liferay Social Office is free
+ * software: you can redistribute it and/or modify it under the terms of the GNU
+ * Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Liferay Social Office is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Liferay Social Office. If not, see http://www.gnu.org/licenses/agpl-3.0.html.
+ */
+
+package com.liferay.so.hook.upgrade;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.so.hook.upgrade.v2_0_4.UpgradeGroup;
+
+/**
+ * @author Jonathan Lee
+ */
+public class UpgradeProcess_2_0_4 extends UpgradeProcess {
+
+	@Override
+	public int getThreshold() {
+		return 204;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		upgrade(UpgradeGroup.class);
+	}
+
+}

--- a/hooks/so-hook/docroot/WEB-INF/src/com/liferay/so/hook/upgrade/v2_0_4/UpgradeGroup.java
+++ b/hooks/so-hook/docroot/WEB-INF/src/com/liferay/so/hook/upgrade/v2_0_4/UpgradeGroup.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This file is part of Liferay Social Office. Liferay Social Office is free
+ * software: you can redistribute it and/or modify it under the terms of the GNU
+ * Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Liferay Social Office is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Liferay Social Office. If not, see http://www.gnu.org/licenses/agpl-3.0.html.
+ */
+
+package com.liferay.so.hook.upgrade.v2_0_4;
+
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.deploy.DeployManagerUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.LayoutSet;
+import com.liferay.portal.service.GroupLocalServiceUtil;
+import com.liferay.portal.service.LayoutSetLocalServiceUtil;
+
+import java.util.List;
+
+/**
+ * @author Jonathan Lee
+ */
+public class UpgradeGroup extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		// This is a Social Office EE upgrade.
+	}
+
+}

--- a/hooks/so-hook/docroot/WEB-INF/src/portal.properties
+++ b/hooks/so-hook/docroot/WEB-INF/src/portal.properties
@@ -1,9 +1,10 @@
-release.info.build.number=203
+release.info.build.number=204
 release.info.previous.build.number=150
 
 upgrade.processes=\
     com.liferay.so.hook.upgrade.UpgradeProcess_2_0_2,\
-    com.liferay.so.hook.upgrade.UpgradeProcess_2_0_3
+    com.liferay.so.hook.upgrade.UpgradeProcess_2_0_3,\
+    com.liferay.so.hook.upgrade.UpgradeProcess_2_0_4
 
 users.image.max.height=400
 users.image.max.width=200


### PR DESCRIPTION
I am using the upgradeProcess to remove so-welcome-theme and also setting all the sites using so-welcome-theme to use classic theme. I think upgradeProcess is a good way to do this because it will only run once.

I committed the code into all branches. For CE versions, UpgradeGroup will do nothing. For EE it will execute the script. I think this way we can update the upgradeprocess to 2_0_4 for all versions, and it won't be confusing to maintain in the future.
