### PR TITLE
LPS-40873 Add initiated timestamp to WebRTCConnection

### DIFF
--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCConnection.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCConnection.java
@@ -23,6 +23,14 @@ public class WebRTCConnection {
 		_webRTCClient = webRTCClient;
 	}
 
+	public long getInitatedTimestampMs() {
+		if (_initiatedTimestampMs == 0) {
+			return 0;
+		}
+
+		return System.currentTimeMillis() - _initiatedTimestampMs;
+	}
+
 	public State getState() {
 		return _state;
 	}
@@ -35,8 +43,10 @@ public class WebRTCConnection {
 		_state = state;
 
 		if (state == State.INITIATED) {
+			_initiatedTimestampMs = System.currentTimeMillis();
 		}
 		else {
+			_initiatedTimestampMs = 0;
 		}
 	}
 
@@ -46,6 +56,7 @@ public class WebRTCConnection {
 
 	}
 
+	private long _initiatedTimestampMs = 0;
 	private State _state = State.DISCONNECTED;
 	private WebRTCClient _webRTCClient;
 


### PR DESCRIPTION
I think `initiatedTimestampMs` explains the purpose of this attribute.
According to Wikipedia, a timestamp is:

  a sequence of characters or encoded information identifying when a
  certain event occurred, usually giving date and time of day,
  sometimes accurate to a small fraction of a second.

The `Ms` suffix is added to specify that it's a timestamp in
milliseconds since Unix timestamps are most commonly in seconds.
