### PR TITLE
LPS-40873 Add WebRTCClient mailbox and abstract mail

### DIFF
--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCClient.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCClient.java
@@ -14,6 +14,8 @@
 
 package com.liferay.chat.video;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -86,6 +88,50 @@ public class WebRTCClient {
 	protected void removeUnilateralWebRTCConnection(WebRTCClient webRTCClient) {
 		_webRTCConnections.remove(webRTCClient);
 	}
+
+    public static class Mailbox {
+
+        private List<Mailbox.Mail> _mails = new ArrayList<Mailbox.Mail>();
+
+        public void pushMail(Mailbox.Mail mail) {
+            _mails.add(mail);
+        }
+
+        public List<Mailbox.Mail> popAllMails() {
+            List<Mailbox.Mail> allMails = new ArrayList<Mailbox.Mail>(_mails);
+            _mails.clear();
+
+            return allMails;
+        }
+
+        public static abstract class Mail {
+
+            private long _fromUserId;
+            private String _jsonMessage;
+
+            public Mail(Mailbox.Mail mail) {
+                _fromUserId = mail._fromUserId;
+                _jsonMessage = mail._jsonMessage;
+            }
+
+            public Mail(long fromUserId, String jsonMessage) {
+                _fromUserId = fromUserId;
+                _jsonMessage = jsonMessage;
+            }
+
+            public long getFromUserId() {
+                return _fromUserId;
+            }
+
+            public String getJsonMessage() {
+                return _jsonMessage;
+            }
+
+            public abstract String getMsgType();
+
+        }
+
+    }
 
 	private boolean _available;
 	private long _presenceTime;

--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCConnection.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCConnection.java
@@ -19,8 +19,12 @@ package com.liferay.chat.video;
  */
 public class WebRTCConnection {
 
-	public WebRTCConnection(WebRTCClient webRTCClient) {
-		_webRTCClient = webRTCClient;
+	public WebRTCConnection(WebRTCClient callingWebRTCClient) {
+		_callingWebRTCClient = callingWebRTCClient;
+	}
+
+	public WebRTCClient getCallingWebRTCClient() {
+		return _callingWebRTCClient;
 	}
 
 	public long getInitiatedDurationTime() {
@@ -33,10 +37,6 @@ public class WebRTCConnection {
 
 	public State getState() {
 		return _state;
-	}
-
-	public WebRTCClient getWebRTCClient() {
-		return _webRTCClient;
 	}
 
 	public void setState(State state) {
@@ -56,8 +56,8 @@ public class WebRTCConnection {
 
 	}
 
+	private WebRTCClient _callingWebRTCClient;
 	private long _initiatedTime = 0;
 	private State _state = State.DISCONNECTED;
-	private WebRTCClient _webRTCClient;
 
 }


### PR DESCRIPTION
Two things to note here.

First, in `WebRTCConnection`, I added `calling` prefixes to all `WebRTCClient` since we want to emphasize that this attribute is the client that initiated the call (a connection connects two peers). I believe that having only a `_webRTCClient` is ambiguous in this situation.

Now, for the mailbox and mail, I don't know your opinion about public static nested classes, so I'm taking a chance. Tell me if you want them as separate files.
