### PR TITLE
LPS-43993

### DIFF
--- a/portlets/marketplace-portlet/docroot/WEB-INF/src/com/liferay/marketplace/util/MarketplaceLicenseUtil.java
+++ b/portlets/marketplace-portlet/docroot/WEB-INF/src/com/liferay/marketplace/util/MarketplaceLicenseUtil.java
@@ -58,12 +58,12 @@ public class MarketplaceLicenseUtil {
 			currentThread.setContextClassLoader(
 				PortalClassLoaderUtil.getClassLoader());
 
-			MethodKey _sendRequestMethodKey = new MethodKey(
+			MethodKey methodKey = new MethodKey(
 				"com.liferay.portal.license.util.LicenseUtil", "sendRequest",
 				String.class);
 
 			response = (String)PortalClassInvoker.invoke(
-				false, _sendRequestMethodKey, jsonObject.toString());
+				false, methodKey, jsonObject.toString());
 		}
 		finally {
 			currentThread.setContextClassLoader(classLoader);
@@ -96,12 +96,12 @@ public class MarketplaceLicenseUtil {
 			currentThread.setContextClassLoader(
 				PortalClassLoaderUtil.getClassLoader());
 
-			MethodKey _registerOrderMethodKey = new MethodKey(
+			MethodKey methodKey = new MethodKey(
 				"com.liferay.portal.license.util.LicenseUtil", "registerOrder",
 				String.class, String.class, int.class);
 
 			PortalClassInvoker.invoke(
-				false, _registerOrderMethodKey, orderUuid, productEntryName, 0);
+				false, methodKey, orderUuid, productEntryName, 0);
 		}
 		finally {
 			currentThread.setContextClassLoader(classLoader);


### PR DESCRIPTION
Question... `MethodKey` has deprecated a constructor that allows us to pass a class name in favor for passing the class object. How are we going to call methods not available to plugins in the future?
