### PR TITLE
LPS-40873 Add concrete WebRTC mail classes

### DIFF
--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCConnectionStateMail.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCConnectionStateMail.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.chat.video;
+
+/**
+ * @author Philippe Proulx
+ */
+public class WebRTCConnectionStateMail extends WebRTCMail {
+
+	public WebRTCConnectionStateMail(long sourceUserId, String messageJSON) {
+		super(sourceUserId, messageJSON);
+	}
+
+	public WebRTCConnectionStateMail(WebRTCConnectionStateMail webRTCMail) {
+		super(webRTCMail);
+	}
+
+	public String getMessageType() {
+		return "conn";
+	}
+
+}

--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCErrorMail.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCErrorMail.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.chat.video;
+
+/**
+ * @author Philippe Proulx
+ */
+public class WebRTCErrorMail extends WebRTCMail {
+
+	public WebRTCErrorMail(long sourceUserId, String messageJSON) {
+		super(sourceUserId, messageJSON);
+	}
+
+	public WebRTCErrorMail(WebRTCErrorMail webRTCMail) {
+		super(webRTCMail);
+	}
+
+	public String getMessageType() {
+		return "err";
+	}
+
+}

--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCICECandidateMail.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCICECandidateMail.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.chat.video;
+
+/**
+ * @author Philippe Proulx
+ */
+public class WebRTCICECandidateMail extends WebRTCMail {
+
+	public WebRTCICECandidateMail(long sourceUserId, String messageJSON) {
+		super(sourceUserId, messageJSON);
+	}
+
+	public WebRTCICECandidateMail(WebRTCICECandidateMail webRTCMail) {
+		super(webRTCMail);
+	}
+
+	public String getMessageType() {
+		return "ice";
+	}
+
+}

--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCSDPDescriptionMail.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCSDPDescriptionMail.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.chat.video;
+
+/**
+ * @author Philippe Proulx
+ */
+public class WebRTCSDPDescriptionMail extends WebRTCMail {
+
+	public WebRTCSDPDescriptionMail(long sourceUserId, String messageJSON) {
+		super(sourceUserId, messageJSON);
+	}
+
+	public WebRTCSDPDescriptionMail(WebRTCSDPDescriptionMail webRTCMail) {
+		super(webRTCMail);
+	}
+
+	public String getMessageType() {
+		return "sdp";
+	}
+
+}


### PR DESCRIPTION
This adds four WebRTC mail classes. Since they are all the same currently except for the message type they return, perhaps an alternative would be to make WebRTCMail concrete and instanciate one with a given type (a constant static string defined somewhere).

On the other hand, I feel like subclassing like it's currently done is better software engineering since adding a new mail type means implementing a new class, not adding a constant to a set of pre-defined strings. All mail classes could be in another package though.

This actual string returned by `getMessageType()` is important since it's given as is to the client-side when it asks for new mails in its inbox.

Tell me what you think.
