### PR TITLE
LPS-40873 Make WebRTCMail hold a JSONObject instead of a string

### DIFF
--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/ConnectionStateWebRTCMail.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/ConnectionStateWebRTCMail.java
@@ -14,6 +14,8 @@
 
 package com.liferay.chat.video;
 
+import com.liferay.portal.kernel.json.JSONObject;
+
 /**
  * @author Philippe Proulx
  */
@@ -25,8 +27,8 @@ public class ConnectionStateWebRTCMail extends WebRTCMail {
 		super(connectionStateWebRTCMail);
 	}
 
-	public ConnectionStateWebRTCMail(long sourceUserId, String messageJSON) {
-		super(sourceUserId, messageJSON);
+	public ConnectionStateWebRTCMail(long sourceUserId, JSONObject messageJSONObject) {
+		super(sourceUserId, messageJSONObject);
 	}
 
 	@Override

--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/DescriptionWebRTCSDPMail.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/DescriptionWebRTCSDPMail.java
@@ -14,6 +14,8 @@
 
 package com.liferay.chat.video;
 
+import com.liferay.portal.kernel.json.JSONObject;
+
 /**
  * @author Philippe Proulx
  */
@@ -25,8 +27,8 @@ public class DescriptionWebRTCSDPMail extends WebRTCMail {
 		super(descriptionWebRTCSDPMail);
 	}
 
-	public DescriptionWebRTCSDPMail(long sourceUserId, String messageJSON) {
-		super(sourceUserId, messageJSON);
+	public DescriptionWebRTCSDPMail(long sourceUserId, JSONObject messageJSONObject) {
+		super(sourceUserId, messageJSONObject);
 	}
 
 	@Override

--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/ErrorWebRTCMail.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/ErrorWebRTCMail.java
@@ -14,6 +14,8 @@
 
 package com.liferay.chat.video;
 
+import com.liferay.portal.kernel.json.JSONObject;
+
 /**
  * @author Philippe Proulx
  */
@@ -23,8 +25,8 @@ public class ErrorWebRTCMail extends WebRTCMail {
 		super(errorWebRTCMail);
 	}
 
-	public ErrorWebRTCMail(long sourceUserId, String messageJSON) {
-		super(sourceUserId, messageJSON);
+	public ErrorWebRTCMail(long sourceUserId, JSONObject messageJSONObject) {
+		super(sourceUserId, messageJSONObject);
 	}
 
 	@Override

--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/ICECandidateWebRTCMail.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/ICECandidateWebRTCMail.java
@@ -14,6 +14,8 @@
 
 package com.liferay.chat.video;
 
+import com.liferay.portal.kernel.json.JSONObject;
+
 /**
  * @author Philippe Proulx
  */
@@ -25,8 +27,8 @@ public class ICECandidateWebRTCMail extends WebRTCMail {
 		super(iceCandidateWebRTCMail);
 	}
 
-	public ICECandidateWebRTCMail(long sourceUserId, String messageJSON) {
-		super(sourceUserId, messageJSON);
+	public ICECandidateWebRTCMail(long sourceUserId, JSONObject messageJSONObject) {
+		super(sourceUserId, messageJSONObject);
 	}
 
 	@Override

--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCMail.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCMail.java
@@ -14,23 +14,29 @@
 
 package com.liferay.chat.video;
 
+import com.liferay.portal.kernel.json.JSONObject;
+
 /**
  * @author Philippe Proulx
  */
 public abstract class WebRTCMail {
 
-	public WebRTCMail(long sourceUserId, String messageJSON) {
+	public WebRTCMail(long sourceUserId, JSONObject messageJSONObject) {
 		_sourceUserId = sourceUserId;
-		_messageJSON = messageJSON;
+		_messageJSONObject = messageJSONObject;
 	}
 
 	public WebRTCMail(WebRTCMail webRTCMail) {
 		_sourceUserId = webRTCMail._sourceUserId;
-		_messageJSON = webRTCMail._messageJSON;
+		_messageJSONObject = webRTCMail._messageJSONObject;
 	}
 
-	public String getMessageJSON() {
-		return _messageJSON;
+	public JSONObject getMessageJSON() {
+		return _messageJSONObject;
+	}
+
+	public String getMessageJSONString() {
+		return _messageJSONObject.toString();
 	}
 
 	public abstract String getMessageType();
@@ -39,7 +45,7 @@ public abstract class WebRTCMail {
 		return _sourceUserId;
 	}
 
-	private final String _messageJSON;
+	private final JSONObject _messageJSONObject;
 	private final long _sourceUserId;
 
 }

--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCManager.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCManager.java
@@ -116,24 +116,22 @@ public class WebRTCManager {
 				messageJSONObject.put("status", "lost");
 				messageJSONObject.put("type", "status");
 
-				String messageJSON = messageJSONObject.toString();
+				pushConnectionStateWebRTCMail(
+					webRTCClient, otherWebRTCClient, messageJSONObject);
 
 				pushConnectionStateWebRTCMail(
-					webRTCClient, otherWebRTCClient, messageJSON);
-
-				pushConnectionStateWebRTCMail(
-					otherWebRTCClient, webRTCClient, messageJSON);
+					otherWebRTCClient, webRTCClient, messageJSONObject);
 			}
 		}
 	}
 
 	protected void pushConnectionStateWebRTCMail(
 		WebRTCClient sourceWebRTCClient, WebRTCClient destinationWebRTCClient,
-		String messageJSON) {
+		JSONObject messageJSONObject) {
 
 		ConnectionStateWebRTCMail connectionStateWebRTCMail =
 			new ConnectionStateWebRTCMail(
-				sourceWebRTCClient.getUserId(), messageJSON);
+				sourceWebRTCClient.getUserId(), messageJSONObject);
 
 		WebRTCMailbox destinationWebRTCMailbox =
 			destinationWebRTCClient.getOutgoingWebRTCMailbox();


### PR DESCRIPTION
Your last changes made me realize that it will be cleaner to have `WebRTCMail`s hold `JSONObject`s instead of plain JSON strings. I added a `getMessageJSONString()` for the final user that wants a string (perhaps it should simply be `toString()` instead).
