### PR TITLE
LPS-40873 WebRTCManager: add processMessageReset() and isWebRTCConnectionStateValid()

### DIFF
--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCClient.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCClient.java
@@ -55,6 +55,10 @@ public class WebRTCClient {
 		return _webRTCConnections.get(webRTCClient);
 	}
 
+	public boolean hasWebRTCConnection(WebRTCClient webRTCClient) {
+		return _webRTCConnections.containsKey(webRTCClient);
+	}
+
 	public boolean isAvailable() {
 		return _available;
 	}

--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCManager.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCManager.java
@@ -59,6 +59,10 @@ public class WebRTCManager {
 		return webRTCClient.isAvailable();
 	}
 
+	public void processMessageReset(long userId) {
+		resetWebRTCClient(userId);
+	}
+
 	public void removeWebRTCClient(long userId) {
 		WebRTCClient webRTCClient = getWebRTCClient(userId);
 
@@ -79,6 +83,37 @@ public class WebRTCManager {
 		}
 
 		webRTCClient.updatePresenceTime();
+	}
+
+	protected static boolean isWebRTCConnectionStateValid(
+		WebRTCClient webRTCClientA, WebRTCClient webRTCClientB,
+		WebRTCConnection.State expectedState) {
+
+		boolean webRTCConnectionAToBExists = webRTCClientA.hasWebRTCConnection(
+			webRTCClientB);
+
+		boolean webRTCConnectionBToAExists = webRTCClientB.hasWebRTCConnection(
+			webRTCClientA);
+
+		if (!webRTCConnectionAToBExists || !webRTCConnectionBToAExists) {
+			return false;
+		}
+
+		WebRTCConnection webRTCConnectionAToB =
+			webRTCClientA.getWebRTCConnection(webRTCClientB);
+
+		WebRTCConnection webRTCConnectionBToA =
+			webRTCClientB.getWebRTCConnection(webRTCClientA);
+
+		if (webRTCConnectionAToB != webRTCConnectionBToA) {
+			return false;
+		}
+
+		if (webRTCConnectionAToB.getState() != expectedState) {
+			return false;
+		}
+
+		return true;
 	}
 
 	protected void addWebRTCClient(long userId) {


### PR DESCRIPTION
I think it's cleaner to add `hasWebRTCConnection()` to `WebRTCClient` than getting the connection and comparing to `null` everytime. The method could also be named `hasWebRTCConnectionWith()` to be more explicit.
