### PR TITLE
LPS-40873 WebRTCManager: tasks called by schedulers

### DIFF
--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCManager.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCManager.java
@@ -29,6 +29,18 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class WebRTCManager {
 
+	public static void checkWebRTCClientsTask() {
+		for (WebRTCManager webRTCManager : _webRTCManagers) {
+			webRTCManager.checkWebRTCClients();
+		}
+	}
+
+	public static void checkWebRTCConnectionsStatesTask() {
+		for (WebRTCManager webRTCManager : _webRTCManagers) {
+			webRTCManager.checkWebRTCConnectionsStates();
+		}
+	}
+
 	public WebRTCManager() {
 		_webRTCManagers.add(this);
 	}


### PR DESCRIPTION
These two methods have to be static because they will be called by schedulers.
