### PR TITLE
LPS-40873 Poller: allow empty mails array

### DIFF
--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/poller/ChatVideoPollerProcessor.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/poller/ChatVideoPollerProcessor.java
@@ -54,9 +54,9 @@ public class ChatVideoPollerProcessor extends BasePollerProcessor {
 		WebRTCClient webRTCClient = _webRTCManager.getWebRTCClient(
 			pollerRequest.getUserId());
 
-		if (webRTCClient != null) {
-			JSONArray webRTCMailsJSONArray = JSONFactoryUtil.createJSONArray();
+		JSONArray webRTCMailsJSONArray = JSONFactoryUtil.createJSONArray();
 
+		if (webRTCClient != null) {
 			WebRTCMailbox webRTCMailbox =
 				webRTCClient.getOutgoingWebRTCMailbox();
 
@@ -72,9 +72,9 @@ public class ChatVideoPollerProcessor extends BasePollerProcessor {
 
 				webRTCMailsJSONArray.put(mailJSONObject);
 			}
-
-			webRTCResponseJSONObject.put("mails", webRTCMailsJSONArray);
 		}
+
+		webRTCResponseJSONObject.put("mails", webRTCMailsJSONArray);
 
 		pollerResponse.setParameter("webRTCResponse", webRTCResponseJSONObject);
 	}


### PR DESCRIPTION
In fact, it wasn't like this for nothing. I prefered having an empty mails array to signify "no mails" to the front-end than having no mails array at all. This simplifies the front-end (and doesn't really complexify the back-end) since it will just iterate all received mails instead of checking if the property exists, and then iterating if so.

Tell me if you agree.
