### PR TITLE
sr-32

### DIFF
--- a/shared/sync-engine-shared/src/com/liferay/sync/engine/util/OSDetector.java
+++ b/shared/sync-engine-shared/src/com/liferay/sync/engine/util/OSDetector.java
@@ -14,8 +14,6 @@
 
 package com.liferay.sync.engine.util;
 
-import com.liferay.portal.kernel.util.StringUtil;
-
 import java.io.File;
 
 /**
@@ -28,7 +26,7 @@ public class OSDetector {
 			return _aix.booleanValue();
 		}
 
-		String osName = StringUtil.toLowerCase(System.getProperty("os.name"));
+		String osName = System.getProperty("os.name").toLowerCase();
 
 		if (osName.equals("aix")) {
 			_aix = Boolean.TRUE;
@@ -45,7 +43,7 @@ public class OSDetector {
 			return _apple.booleanValue();
 		}
 
-		String osName = StringUtil.toLowerCase(System.getProperty("os.name"));
+		String osName = System.getProperty("os.name").toLowerCase();
 
 		if (osName.contains("mac")) {
 			_apple = Boolean.TRUE;


### PR DESCRIPTION
Hey @hhuijser,

Can you make changes to the source formatter so that -shared plugins don't have to use portal classes (StringUtil, SecureRandomUtil)? That way, we don't have to add exclusions for every instance.
