### PR TITLE
LPS-43009 Missing commit: use the right context for plugins and portal resources

### DIFF
--- a/hooks/rtl-hook/docroot/WEB-INF/liferay-hook.xml
+++ b/hooks/rtl-hook/docroot/WEB-INF/liferay-hook.xml
@@ -9,7 +9,7 @@
 	</servlet-filter>
 	<servlet-filter>
 		<servlet-filter-name>Dynamic CSS Filter</servlet-filter-name>
-		<servlet-filter-impl>com.liferay.rtl.hook.filter.dynamiccss.DynamicCSSFilter</servlet-filter-impl>
+		<servlet-filter-impl>com.liferay.rtl.hook.filter.dynamiccss.PortalDynamicCSSFilter</servlet-filter-impl>
 	</servlet-filter>
 	<servlet-filter-mapping>
 		<servlet-filter-name>Combo Servlet Filter</servlet-filter-name>

--- a/hooks/rtl-hook/docroot/WEB-INF/src/com/liferay/rtl/hook/filter/dynamiccss/DynamicCSSFilter.java
+++ b/hooks/rtl-hook/docroot/WEB-INF/src/com/liferay/rtl/hook/filter/dynamiccss/DynamicCSSFilter.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.BufferCacheServletResponse;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
-import com.liferay.portal.kernel.servlet.ServletContextPool;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -30,7 +29,6 @@ import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.util.PortalUtil;
 import com.liferay.rtl.hook.filter.IgnoreModuleRequestFilter;
 
 import java.io.File;
@@ -58,12 +56,17 @@ public class DynamicCSSFilter extends IgnoreModuleRequestFilter {
 
 	@Override
 	public void init(FilterConfig filterConfig) {
+		doInit(filterConfig, filterConfig.getServletContext());
+	}
+
+	protected void doInit(
+		FilterConfig filterConfig, ServletContext servletContext) {
+
 		super.init(filterConfig);
 
-		_servletContext = ServletContextPool.get(
-			PortalUtil.getServletContextName());
+		_servletContext = servletContext;
 
-		File tempDir = (File)_servletContext.getAttribute(
+		File tempDir = (File)servletContext.getAttribute(
 			JavaConstants.JAVAX_SERVLET_CONTEXT_TEMPDIR);
 
 		_tempDir = new File(tempDir, _TEMP_DIR);

--- a/hooks/rtl-hook/docroot/WEB-INF/src/com/liferay/rtl/hook/filter/dynamiccss/PortalDynamicCSSFilter.java
+++ b/hooks/rtl-hook/docroot/WEB-INF/src/com/liferay/rtl/hook/filter/dynamiccss/PortalDynamicCSSFilter.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.rtl.hook.filter.dynamiccss;
+
+import com.liferay.portal.kernel.servlet.ServletContextPool;
+import com.liferay.portal.util.PortalUtil;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+
+/**
+ * @author Eduardo Lundgren
+ * @author Raymond Augé
+ * @author Eduardo Garcia
+ * @see com.liferay.rtl.hook.filter.dynamiccss.DynamicCSSFilter
+ */
+public class PortalDynamicCSSFilter extends DynamicCSSFilter {
+
+	@Override
+	public void init(FilterConfig filterConfig) {
+		ServletContext servletContext = ServletContextPool.get(
+			PortalUtil.getServletContextName());
+
+		super.doInit(filterConfig, servletContext);
+	}
+
+}

--- a/hooks/rtl-hook/docroot/WEB-INF/src/com/liferay/rtl/hook/filter/dynamiccss/RTLCSSUtil.java
+++ b/hooks/rtl-hook/docroot/WEB-INF/src/com/liferay/rtl/hook/filter/dynamiccss/RTLCSSUtil.java
@@ -53,7 +53,13 @@ public class RTLCSSUtil {
 	}
 
 	public static void init() {
-		init(PortletClassLoaderUtil.getClassLoader());
+		ClassLoader classLoader = PortletClassLoaderUtil.getClassLoader();
+
+		if (classLoader == null) {
+			classLoader = RTLCSSUtil.class.getClassLoader();
+		}
+
+		init(classLoader);
 	}
 
 	public static void init(ClassLoader classLoader) {


### PR DESCRIPTION
Hey Brian,

I'm afraid I missed these changes. They were included in my very first pull-request for LPS-43009 (see https://github.com/epgarcia/liferay-plugins/commit/34b7eb43888a2dd56b326953d12e1a57bbf51398) but I guess that they got lost during the re-sending and re-basing. I noticed it while preparing a complete demo of the RTL hook.

Basically, we need to use the portal context to serve the portal CSS resources that have been overwritten by the hook, and use the plugin context to serve the theme CSS resources. Thus, we now have two filters, one for plugins (DynamicCSSFilter) and one for portal resources (PortalDynamicCSSFilter). The latest extends the first and simply initializes itself with the appropriate context.

Thank you very much
