### PR TITLE
LPS-40873 Do not remove connections when setting availability

### DIFF
--- a/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCManager.java
+++ b/portlets/chat-video-portlet/docroot/WEB-INF/src/com/liferay/chat/video/WebRTCManager.java
@@ -309,8 +309,6 @@ public class WebRTCManager {
 
 		WebRTCClient webRTCClient = getWebRTCClient(userId);
 
-		webRTCClient.removeBilateralWebRTCConnections();
-
 		webRTCClient.setAvailable(available);
 	}
 


### PR DESCRIPTION
Removing all the connections of a client when changing its availability corrupts all its current chat video calls/conversations. If I set my availability to not available, the current calls/conversations are okay to continue since they were initiated before my action.
