### PR TITLE
LPS-46803 Resolve compilation error

### DIFF
--- a/hooks/rtl-hook/build.xml
+++ b/hooks/rtl-hook/build.xml
@@ -43,7 +43,13 @@
 		</delete>
 	</target>
 
-	<target name="compile" depends="build-common.compile,rtl-jar" />
+	<target name="compile">
+		<compile
+			module.dir="${basedir}"
+		/>
+
+		<antcall target="rtl-jar" />
+	</target>
 
 	<target name="rtl-jar">
 		<zip


### PR DESCRIPTION
Hey Brian,

The issue reported in LPS-46803 only occurs with the SDK of ee-6.2.x, but I've solved it in 6.2.x for consistency. Can you please review it and apply it to ee-6.2.x if it's ok?

Thx!
