### PR TITLE
LPS-46864 Ignore modified date diffs between resource and cache resource

### DIFF
--- a/hooks/rtl-hook/docroot/WEB-INF/src/com/liferay/rtl/hook/filter/dynamiccss/DynamicCSSUtil.java
+++ b/hooks/rtl-hook/docroot/WEB-INF/src/com/liferay/rtl/hook/filter/dynamiccss/DynamicCSSUtil.java
@@ -151,8 +151,8 @@ public class DynamicCSSUtil {
 
 		if (themeCssFastLoad && (cacheResourceURLConnection != null) &&
 			(resourceURLConnection != null) &&
-			(cacheResourceURLConnection.getLastModified() ==
-				resourceURLConnection.getLastModified())) {
+			_isCacheResourceUpToDate(
+				cacheResourceURLConnection, resourceURLConnection)) {
 
 			parsedContent = StringUtil.read(
 				cacheResourceURLConnection.getInputStream());
@@ -396,6 +396,24 @@ public class DynamicCSSUtil {
 		}
 
 		return themeImagesPath;
+	}
+
+	private static boolean _isCacheResourceUpToDate(
+		URLConnection cacheResourceURLConnection,
+		URLConnection resourceURLConnection) {
+
+		if (!_SUPPORTS_THEME_CSS_FAST_LOAD_DISABLED) {
+			return true;
+		}
+
+		if (cacheResourceURLConnection.getLastModified() ==
+				resourceURLConnection.getLastModified()) {
+
+			return true;
+		}
+		else {
+			return false;
+		}
 	}
 
 	private static boolean _isThemeCssFastLoad(


### PR DESCRIPTION
Hey Brian,

@jhinkey reported some issues in Windows. I noticed that in this OS, the modified dates of the resource (the original file) and its cache resource are different by a few milliseconds. I assume this difference is caused by the way in which resources and cache resources are deployed from the hook into the portal. 

This logic corresponds to another case in which SASS files are parsed on the fly (because their cache is out-of-date). This cannot happen in this version, so I've bypassed it in a similar way as we did with the themeCssFastLoad.

I'll review this difference when I start working on the support for dynamic CSS generation in the RTL-hook.

Thnx!
