### PR TITLE
This fixes test-localized-portlet in for 6.2.x branch. 

### DIFF
--- a/portlets/test-localized-portlet/docroot/view.jsp
+++ b/portlets/test-localized-portlet/docroot/view.jsp
@@ -245,9 +245,7 @@ Test only in
 					<%= resourceBundleActualValue %>
 				</td>
 				<td>
-					<liferay-util:buffer var="taglibActualValue">
-						<liferay-ui:message key="<%= key %>" />
-					</liferay-util:buffer>
+					<liferay-util:buffer var="taglibActualValue"><liferay-ui:message key="<%= key %>" /></liferay-util:buffer>
 
 					<%= taglibActualValue %>
 				</td>


### PR DESCRIPTION
The problem is that test portlet leverages on liferay-util:buffer, which in 6.2.x version does not trim extra whitespaces from the output, so the test ends up comparing "blah" to "\n\t\tblah\n\t", thus always failing. 

I push this on to branch 6.2.x but this should work ok in master too.
