### PR TITLE
Pushed to upstream: (Applies to 6.2.x) Jar OSGi modules are packaged as War files, which is incorrect

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1182,297 +1182,201 @@ Please find a solution that does not require portal-impl.jar.
 			<if>
 				<antelope:endswith string="${plugin.name}" with="-ext" />
 				<then>
-					<direct-deploy-ext-cmd
-						direct.deploy.dir="${app.server.deploy.dir}"
-						module.dir="@{module.dir}"
-					/>
+					<java
+						classname="com.liferay.portal.tools.deploy.ExtDeployer"
+						classpathref="portal.classpath"
+						fork="true"
+						newenvironment="true"
+					>
+
+						<!-- Required Arguments -->
+
+						<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
+						<jvmarg value="-Dliferay.lib.portal.dir=${app.server.lib.portal.dir}" />
+						<jvmarg value="-Ddeployer.base.dir=${sdk.dir}/dist" />
+						<jvmarg value="-Ddeployer.dest.dir=${app.server.deploy.dir}" />
+						<jvmarg value="-Ddeployer.app.server.type=${app.server.type}" />
+						<jvmarg value="-Ddeployer.unpack.war=${auto.deploy.unpack.war}" />
+						<jvmarg value="-Ddeployer.file.pattern=${plugin.name}-*.war" />
+
+						<!-- Optional Arguments -->
+
+						<jvmarg value="-Ddeployer.tomcat.lib.dir=${app.server.tomcat.lib.global.dir}" />
+
+						<!-- Dependent Libraries -->
+
+						<arg value="${app.server.lib.portal.dir}/util-bridges.jar" />
+						<arg value="${app.server.lib.portal.dir}/util-java.jar" />
+						<arg value="${app.server.lib.portal.dir}/util-taglib.jar" />
+					</java>
 				</then>
 				<elseif>
 					<antelope:endswith string="${plugin.name}" with="-hook" />
 					<then>
-						<direct-deploy-hook-cmd
-							direct.deploy.dir="${app.server.deploy.dir}"
-							module.dir="@{module.dir}"
-						/>
+						<java
+							classname="com.liferay.portal.tools.deploy.HookDeployer"
+							classpathref="portal.classpath"
+							fork="true"
+							newenvironment="true"
+						>
+
+							<!-- Required Arguments -->
+
+							<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
+							<jvmarg value="-Dliferay.lib.portal.dir=${app.server.lib.portal.dir}" />
+							<jvmarg value="-Ddeployer.base.dir=${sdk.dir}/dist" />
+							<jvmarg value="-Ddeployer.dest.dir=${app.server.deploy.dir}" />
+							<jvmarg value="-Ddeployer.app.server.type=${app.server.type}" />
+							<jvmarg value="-Ddeployer.unpack.war=${auto.deploy.unpack.war}" />
+							<jvmarg value="-Ddeployer.file.pattern=${plugin.name}-*.war" />
+
+							<!-- Optional Arguments -->
+
+							<jvmarg value="-Ddeployer.tomcat.lib.dir=${app.server.tomcat.lib.global.dir}" />
+
+							<!-- Dependent Libraries -->
+
+							<arg value="${app.server.lib.portal.dir}/util-bridges.jar" />
+							<arg value="${app.server.lib.portal.dir}/util-java.jar" />
+							<arg value="${app.server.lib.portal.dir}/util-taglib.jar" />
+						</java>
 					</then>
 				</elseif>
 				<elseif>
 					<antelope:endswith string="${plugin.name}" with="-layouttpl" />
 					<then>
-						<direct-deploy-layouttpl-cmd
-							direct.deploy.dir="${app.server.deploy.dir}"
-							module.dir="@{module.dir}"
-						/>
+						<java
+							classname="com.liferay.portal.tools.deploy.LayoutTemplateDeployer"
+							classpathref="portal.classpath"
+							fork="true"
+							newenvironment="true"
+						>
+
+							<!-- Required Arguments -->
+
+							<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
+							<jvmarg value="-Dliferay.lib.portal.dir=${app.server.lib.portal.dir}" />
+							<jvmarg value="-Ddeployer.base.dir=${sdk.dir}/dist" />
+							<jvmarg value="-Ddeployer.dest.dir=${app.server.deploy.dir}" />
+							<jvmarg value="-Ddeployer.app.server.type=${app.server.type}" />
+							<jvmarg value="-Ddeployer.unpack.war=${auto.deploy.unpack.war}" />
+							<jvmarg value="-Ddeployer.file.pattern=${plugin.name}-*.war" />
+
+							<!-- Dependent Libraries -->
+
+							<arg value="${app.server.lib.portal.dir}/util-bridges.jar" />
+							<arg value="${app.server.lib.portal.dir}/util-java.jar" />
+							<arg value="${app.server.lib.portal.dir}/util-taglib.jar" />
+						</java>
 					</then>
 				</elseif>
 				<elseif>
 					<antelope:endswith string="${plugin.name}" with="-portlet" />
 					<then>
-						<direct-deploy-portlet-cmd
-							direct.deploy.dir="${app.server.deploy.dir}"
-							module.dir="@{module.dir}"
-						/>
+						<java
+							classname="com.liferay.portal.tools.deploy.PortletDeployer"
+							classpathref="portal.classpath"
+							fork="true"
+							newenvironment="true"
+						>
+
+							<!-- Required Arguments -->
+
+							<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
+							<jvmarg value="-Dliferay.lib.portal.dir=${app.server.lib.portal.dir}" />
+							<jvmarg value="-Ddeployer.base.dir=${sdk.dir}/dist" />
+							<jvmarg value="-Ddeployer.dest.dir=${app.server.deploy.dir}" />
+							<jvmarg value="-Ddeployer.app.server.type=${app.server.type}" />
+							<jvmarg value="-Ddeployer.aui.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/aui.tld" />
+							<jvmarg value="-Ddeployer.portlet.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-portlet.tld" />
+							<jvmarg value="-Ddeployer.portlet-ext.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-portlet-ext.tld" />
+							<jvmarg value="-Ddeployer.security.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-security.tld" />
+							<jvmarg value="-Ddeployer.theme.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-theme.tld" />
+							<jvmarg value="-Ddeployer.ui.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-ui.tld" />
+							<jvmarg value="-Ddeployer.util.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-util.tld" />
+							<jvmarg value="-Ddeployer.unpack.war=${auto.deploy.unpack.war}" />
+							<jvmarg value="-Ddeployer.custom.portlet.xml=${auto.deploy.custom.portlet.xml}" />
+							<jvmarg value="-Ddeployer.file.pattern=${plugin.name}-*.war" />
+
+							<!-- Optional Arguments -->
+
+							<jvmarg value="-Ddeployer.tomcat.lib.dir=${app.server.tomcat.lib.global.dir}" />
+
+							<!-- Dependent Libraries -->
+
+							<arg value="${app.server.lib.portal.dir}/util-bridges.jar" />
+							<arg value="${app.server.lib.portal.dir}/util-java.jar" />
+							<arg value="${app.server.lib.portal.dir}/util-taglib.jar" />
+						</java>
 					</then>
 				</elseif>
 				<elseif>
 					<antelope:endswith string="${plugin.name}" with="-theme" />
 					<then>
-						<direct-deploy-theme-cmd
-							direct.deploy.dir="${app.server.deploy.dir}"
-							module.dir="@{module.dir}"
-						/>
+						<java
+							classname="com.liferay.portal.tools.deploy.ThemeDeployer"
+							classpathref="portal.classpath"
+							fork="true"
+							newenvironment="true"
+						>
+
+							<!-- Required Arguments -->
+
+							<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
+							<jvmarg value="-Dliferay.lib.portal.dir=${app.server.lib.portal.dir}" />
+							<jvmarg value="-Ddeployer.base.dir=${sdk.dir}/dist" />
+							<jvmarg value="-Ddeployer.dest.dir=${app.server.deploy.dir}" />
+							<jvmarg value="-Ddeployer.app.server.type=${app.server.type}" />
+							<jvmarg value="-Ddeployer.theme.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-theme.tld" />
+							<jvmarg value="-Ddeployer.util.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-util.tld" />
+							<jvmarg value="-Ddeployer.unpack.war=${auto.deploy.unpack.war}" />
+							<jvmarg value="-Ddeployer.file.pattern=${plugin.name}-*.war" />
+
+							<!-- Optional Arguments -->
+
+							<jvmarg value="-Ddeployer.tomcat.lib.dir=${app.server.tomcat.lib.global.dir}" />
+
+							<!-- Dependent Libraries -->
+
+							<arg value="${app.server.lib.portal.dir}/util-bridges.jar" />
+							<arg value="${app.server.lib.portal.dir}/util-java.jar" />
+							<arg value="${app.server.lib.portal.dir}/util-taglib.jar" />
+						</java>
 					</then>
 				</elseif>
 				<elseif>
 					<antelope:endswith string="${plugin.name}" with="-web" />
 					<then>
-						<direct-deploy-web-cmd
-							direct.deploy.dir="${app.server.deploy.dir}"
-							module.dir="@{module.dir}"
-						/>
+						<java
+							classname="com.liferay.portal.tools.deploy.WebDeployer"
+							classpathref="portal.classpath"
+							fork="true"
+							newenvironment="true"
+						>
+
+							<!-- Required Arguments -->
+
+							<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
+							<jvmarg value="-Dliferay.lib.portal.dir=${app.server.lib.portal.dir}" />
+							<jvmarg value="-Ddeployer.base.dir=${sdk.dir}/dist" />
+							<jvmarg value="-Ddeployer.dest.dir=${app.server.deploy.dir}" />
+							<jvmarg value="-Ddeployer.app.server.type=${app.server.type}" />
+							<jvmarg value="-Ddeployer.unpack.war=${auto.deploy.unpack.war}" />
+							<jvmarg value="-Ddeployer.file.pattern=${plugin.name}-*.war" />
+
+							<!-- Optional Arguments -->
+
+							<jvmarg value="-Ddeployer.tomcat.lib.dir=${app.server.tomcat.lib.global.dir}" />
+
+							<!-- Dependent Libraries -->
+
+							<arg value="${app.server.lib.portal.dir}/util-bridges.jar" />
+							<arg value="${app.server.lib.portal.dir}/util-java.jar" />
+							<arg value="${app.server.lib.portal.dir}/util-taglib.jar" />
+						</java>
 					</then>
 				</elseif>
 			</if>
-		</sequential>
-	</macrodef>
-
-	<macrodef name="direct-deploy-ext-cmd">
-		<attribute name="direct.deploy.dir" />
-		<attribute name="module.dir" />
-
-		<sequential>
-			<set-module-properties
-				module.dir="@{module.dir}"
-			/>
-
-			<java
-				classname="com.liferay.portal.tools.deploy.ExtDeployer"
-				classpathref="portal.classpath"
-				fork="true"
-				newenvironment="true"
-			>
-
-				<!-- Required Arguments -->
-
-				<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-				<jvmarg value="-Dliferay.lib.portal.dir=${app.server.lib.portal.dir}" />
-				<jvmarg value="-Ddeployer.base.dir=${sdk.dir}/dist" />
-				<jvmarg value="-Ddeployer.dest.dir=@{direct.deploy.dir}" />
-				<jvmarg value="-Ddeployer.app.server.type=${app.server.type}" />
-				<jvmarg value="-Ddeployer.unpack.war=${auto.deploy.unpack.war}" />
-				<jvmarg value="-Ddeployer.file.pattern=${plugin.name}-*.war" />
-
-				<!-- Optional Arguments -->
-
-				<jvmarg value="-Ddeployer.tomcat.lib.dir=${app.server.tomcat.lib.global.dir}" />
-
-				<!-- Dependent Libraries -->
-
-				<arg value="${app.server.lib.portal.dir}/util-bridges.jar" />
-				<arg value="${app.server.lib.portal.dir}/util-java.jar" />
-				<arg value="${app.server.lib.portal.dir}/util-taglib.jar" />
-			</java>
-		</sequential>
-	</macrodef>
-
-	<macrodef name="direct-deploy-hook-cmd">
-		<attribute name="direct.deploy.dir" />
-		<attribute name="module.dir" />
-
-		<sequential>
-			<set-module-properties
-				module.dir="@{module.dir}"
-			/>
-
-			<java
-				classname="com.liferay.portal.tools.deploy.HookDeployer"
-				classpathref="portal.classpath"
-				fork="true"
-				newenvironment="true"
-			>
-
-				<!-- Required Arguments -->
-
-				<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-				<jvmarg value="-Dliferay.lib.portal.dir=${app.server.lib.portal.dir}" />
-				<jvmarg value="-Ddeployer.base.dir=${sdk.dir}/dist" />
-				<jvmarg value="-Ddeployer.dest.dir=@{direct.deploy.dir}" />
-				<jvmarg value="-Ddeployer.app.server.type=${app.server.type}" />
-				<jvmarg value="-Ddeployer.unpack.war=${auto.deploy.unpack.war}" />
-				<jvmarg value="-Ddeployer.file.pattern=${plugin.name}-*.war" />
-
-				<!-- Optional Arguments -->
-
-				<jvmarg value="-Ddeployer.tomcat.lib.dir=${app.server.tomcat.lib.global.dir}" />
-
-				<!-- Dependent Libraries -->
-
-				<arg value="${app.server.lib.portal.dir}/util-bridges.jar" />
-				<arg value="${app.server.lib.portal.dir}/util-java.jar" />
-				<arg value="${app.server.lib.portal.dir}/util-taglib.jar" />
-			</java>
-		</sequential>
-	</macrodef>
-
-	<macrodef name="direct-deploy-layouttpl-cmd">
-		<attribute name="direct.deploy.dir" />
-		<attribute name="module.dir" />
-
-		<sequential>
-			<set-module-properties
-				module.dir="@{module.dir}"
-			/>
-
-			<java
-				classname="com.liferay.portal.tools.deploy.LayoutTemplateDeployer"
-				classpathref="portal.classpath"
-				fork="true"
-				newenvironment="true"
-			>
-
-				<!-- Required Arguments -->
-
-				<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-				<jvmarg value="-Dliferay.lib.portal.dir=${app.server.lib.portal.dir}" />
-				<jvmarg value="-Ddeployer.base.dir=${sdk.dir}/dist" />
-				<jvmarg value="-Ddeployer.dest.dir=@{direct.deploy.dir}" />
-				<jvmarg value="-Ddeployer.app.server.type=${app.server.type}" />
-				<jvmarg value="-Ddeployer.unpack.war=${auto.deploy.unpack.war}" />
-				<jvmarg value="-Ddeployer.file.pattern=${plugin.name}-*.war" />
-
-				<!-- Dependent Libraries -->
-
-				<arg value="${app.server.lib.portal.dir}/util-bridges.jar" />
-				<arg value="${app.server.lib.portal.dir}/util-java.jar" />
-				<arg value="${app.server.lib.portal.dir}/util-taglib.jar" />
-			</java>
-		</sequential>
-	</macrodef>
-
-	<macrodef name="direct-deploy-portlet-cmd">
-		<attribute name="direct.deploy.dir" />
-		<attribute name="module.dir" />
-
-		<sequential>
-			<set-module-properties
-				module.dir="@{module.dir}"
-			/>
-
-			<java
-				classname="com.liferay.portal.tools.deploy.PortletDeployer"
-				classpathref="portal.classpath"
-				fork="true"
-				newenvironment="true"
-			>
-
-				<!-- Required Arguments -->
-
-				<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-				<jvmarg value="-Dliferay.lib.portal.dir=${app.server.lib.portal.dir}" />
-				<jvmarg value="-Ddeployer.base.dir=${sdk.dir}/dist" />
-				<jvmarg value="-Ddeployer.dest.dir=@{direct.deploy.dir}" />
-				<jvmarg value="-Ddeployer.app.server.type=${app.server.type}" />
-				<jvmarg value="-Ddeployer.aui.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/aui.tld" />
-				<jvmarg value="-Ddeployer.portlet.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-portlet.tld" />
-				<jvmarg value="-Ddeployer.portlet-ext.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-portlet-ext.tld" />
-				<jvmarg value="-Ddeployer.security.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-security.tld" />
-				<jvmarg value="-Ddeployer.theme.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-theme.tld" />
-				<jvmarg value="-Ddeployer.ui.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-ui.tld" />
-				<jvmarg value="-Ddeployer.util.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-util.tld" />
-				<jvmarg value="-Ddeployer.unpack.war=${auto.deploy.unpack.war}" />
-				<jvmarg value="-Ddeployer.custom.portlet.xml=${auto.deploy.custom.portlet.xml}" />
-				<jvmarg value="-Ddeployer.file.pattern=${plugin.name}-*.war" />
-
-				<!-- Optional Arguments -->
-
-				<jvmarg value="-Ddeployer.tomcat.lib.dir=${app.server.tomcat.lib.global.dir}" />
-
-				<!-- Dependent Libraries -->
-
-				<arg value="${app.server.lib.portal.dir}/util-bridges.jar" />
-				<arg value="${app.server.lib.portal.dir}/util-java.jar" />
-				<arg value="${app.server.lib.portal.dir}/util-taglib.jar" />
-			</java>
-		</sequential>
-	</macrodef>
-
-	<macrodef name="direct-deploy-theme-cmd">
-		<attribute name="direct.deploy.dir" />
-		<attribute name="module.dir" />
-
-		<sequential>
-			<set-module-properties
-				module.dir="@{module.dir}"
-			/>
-
-			<java
-				classname="com.liferay.portal.tools.deploy.ThemeDeployer"
-				classpathref="portal.classpath"
-				fork="true"
-				newenvironment="true"
-			>
-
-				<!-- Required Arguments -->
-
-				<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-				<jvmarg value="-Dliferay.lib.portal.dir=${app.server.lib.portal.dir}" />
-				<jvmarg value="-Ddeployer.base.dir=${sdk.dir}/dist" />
-				<jvmarg value="-Ddeployer.dest.dir=@{direct.deploy.dir}" />
-				<jvmarg value="-Ddeployer.app.server.type=${app.server.type}" />
-				<jvmarg value="-Ddeployer.theme.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-theme.tld" />
-				<jvmarg value="-Ddeployer.util.taglib.dtd=${app.server.portal.dir}/WEB-INF/tld/liferay-util.tld" />
-				<jvmarg value="-Ddeployer.unpack.war=${auto.deploy.unpack.war}" />
-				<jvmarg value="-Ddeployer.file.pattern=${plugin.name}-*.war" />
-
-				<!-- Optional Arguments -->
-
-				<jvmarg value="-Ddeployer.tomcat.lib.dir=${app.server.tomcat.lib.global.dir}" />
-
-				<!-- Dependent Libraries -->
-
-				<arg value="${app.server.lib.portal.dir}/util-bridges.jar" />
-				<arg value="${app.server.lib.portal.dir}/util-java.jar" />
-				<arg value="${app.server.lib.portal.dir}/util-taglib.jar" />
-			</java>
-		</sequential>
-	</macrodef>
-
-	<macrodef name="direct-deploy-web-cmd">
-		<attribute name="direct.deploy.dir" />
-		<attribute name="module.dir" />
-
-		<sequential>
-			<set-module-properties
-				module.dir="@{module.dir}"
-			/>
-
-			<java
-				classname="com.liferay.portal.tools.deploy.WebDeployer"
-				classpathref="portal.classpath"
-				fork="true"
-				newenvironment="true"
-			>
-
-				<!-- Required Arguments -->
-
-				<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-				<jvmarg value="-Dliferay.lib.portal.dir=${app.server.lib.portal.dir}" />
-				<jvmarg value="-Ddeployer.base.dir=${sdk.dir}/dist" />
-				<jvmarg value="-Ddeployer.dest.dir=@{direct.deploy.dir}" />
-				<jvmarg value="-Ddeployer.app.server.type=${app.server.type}" />
-				<jvmarg value="-Ddeployer.unpack.war=${auto.deploy.unpack.war}" />
-				<jvmarg value="-Ddeployer.file.pattern=${plugin.name}-*.war" />
-
-				<!-- Optional Arguments -->
-
-				<jvmarg value="-Ddeployer.tomcat.lib.dir=${app.server.tomcat.lib.global.dir}" />
-
-				<!-- Dependent Libraries -->
-
-				<arg value="${app.server.lib.portal.dir}/util-bridges.jar" />
-				<arg value="${app.server.lib.portal.dir}/util-java.jar" />
-				<arg value="${app.server.lib.portal.dir}/util-taglib.jar" />
-			</java>
 		</sequential>
 	</macrodef>
 


### PR DESCRIPTION
This reverts commit b33f65e. OSGi modules with a portlet structure fail to deploy. This logic considers that those modules are deployed as wars, but they are actually deployed as jars.
