### PR TITLE
LPS-48843 plugin.name is needed in 6.2.x so that service builder generates all the clp classes

### DIFF
--- a/build-common-plugin.xml
+++ b/build-common-plugin.xml
@@ -31,16 +31,16 @@
 				</else>
 			</if>
 
+			<var name="service.plugin.name" value="${plugin.name}" />
+
 			<if>
 				<available file="bnd.bnd" />
 				<then>
 					<var name="service.osgi.module" value="true" />
-					<var name="service.plugin.name" value="" />
 					<var name="service.spring.namespaces" value="beans,osgi" />
 				</then>
 				<else>
 					<var name="service.osgi.module" value="false" />
-					<var name="service.plugin.name" value="${plugin.name}" />
 					<var name="service.spring.namespaces" value="beans" />
 				</else>
 			</if>


### PR DESCRIPTION
cc @migue has already reviewed this change and confirmed it is not needed in master.
