### PR TITLE
global-theme-ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,10 @@ _sass_cache_*.css
 /build.*.properties
 /dist
 /tools/*/*/*/lib
+
+/themes/*/docroot/css
+/themes/*/docroot/images
+/themes/*/docroot/js
+/themes/*/docroot/templates
+/themes/*/docroot/layouttpl
+/themes/*/docroot/WEB-INF/lib


### PR DESCRIPTION
Heya Brian, I'm sending this over as a proposal to add the rules for ignoring generated theme files to the global gitignore. However, I don't know if there was any cases this doesn't address that led you to create a gitignore per theme file. If this _does_ cover all of the cases, let me know, and we can create a ticket and remove all of the .gitignore files. If it doesn't, I would like to add the .gitignore to the theme_tmpl in tools, so that it's automatically done for developers. But hopefully this will cover our cases :) Thanks Brian,
