### PR TITLE
LPS-48916 change use of server to connection manager

### DIFF
--- a/shared/solr4-shared/src/com/liferay/portal/search/solr/server/BasicAuthSolrServer.java
+++ b/shared/solr4-shared/src/com/liferay/portal/search/solr/server/BasicAuthSolrServer.java
@@ -83,7 +83,7 @@ public class BasicAuthSolrServer extends SolrServer {
 		}
 
 		if (_defaultMaxConnectionsPerRoute != null) {
-			_server.setDefaultMaxConnectionsPerHost(
+			_poolingClientConnectionManager.setDefaultMaxPerRoute(
 				_defaultMaxConnectionsPerRoute);
 		}
 
@@ -92,7 +92,7 @@ public class BasicAuthSolrServer extends SolrServer {
 		}
 
 		if (_maxTotalConnections != null) {
-			_server.setMaxTotalConnections(_maxTotalConnections);
+			_poolingClientConnectionManager.setMaxTotal(_maxTotalConnections);
 		}
 
 		if (_maxRetries != null) {


### PR DESCRIPTION
@holatuwol @mhan810 @hhuijser

these two setters will throw "Caused by: java.lang.UnsupportedOperationException: Client was created outside of HttpSolrServer" errors if we use _server. i've changed the setters to use the connection manager instead, and i can verify that no errors are thrown in the portal.
