### PR TITLE
LPS-50685 unescape title when importing

### DIFF
--- a/portlets/knowledge-base-portlet/docroot/WEB-INF/src/com/liferay/knowledgebase/admin/importer/util/KBArticleMarkdownConverter.java
+++ b/portlets/knowledge-base-portlet/docroot/WEB-INF/src/com/liferay/knowledgebase/admin/importer/util/KBArticleMarkdownConverter.java
@@ -70,7 +70,7 @@ public class KBArticleMarkdownConverter {
 
 		_urlTitle = getUrlTitle(heading);
 
-		_title = stripIds(heading);
+		_title = HtmlUtil.unescape(stripIds(heading));
 
 		html = stripIds(html);
 


### PR DESCRIPTION
The conversion process escapes the title of the article. As the Display
portlet uses escaped models, the result is that the title is doubly
escaped.
