### PR TITLE
[don't backport] LPS-51613 use Bootstrap 3 new CSS class

### DIFF
--- a/portlets/knowledge-base-portlet/docroot/admin/article_siblings.jsp
+++ b/portlets/knowledge-base-portlet/docroot/admin/article_siblings.jsp
@@ -90,7 +90,7 @@ KBArticle nextKBArticle = previousAndNextKBArticles[2];
 				<i class="icon icon-circle-arrow-right"></i>
 			</aui:a>
 
-			<aui:a cssClass="next visible-phone" href="<%= nextKBArticleURL %>">
+			<aui:a cssClass="next visible-xs" href="<%= nextKBArticleURL %>">
 				<span class="title"><liferay-ui:message key="next" /></span>
 
 				<i class="icon icon-circle-arrow-right"></i>


### PR DESCRIPTION
No need to backport, as 6.2.x uses Bootstrap 2.
