### PR TITLE
LPS-52678 Update deploy and clean targets to take into accout WSDD fragments

### DIFF
--- a/build-common-osgi-plugin.xml
+++ b/build-common-osgi-plugin.xml
@@ -4,6 +4,50 @@
 <project name="build-common-osgi-plugin">
 	<import file="build-common-plugin.xml" />
 
+	<path id="wsdd.classpath">
+		<path refid="lib.classpath" />
+		<path refid="portal.classpath" />
+		<fileset dir="lib" includes="*.jar" />
+		<pathelement location="classes" />
+	</path>
+
+	<target name="build-wsdd" depends="compile">
+		<loop-macrodef-or-target
+			module.dirs="${basedir}"
+			target.name="compile"
+		/>
+
+		<build-wsdd
+			wsdd.classpath.property="wsdd.classpath"
+			wsdd.input.file="service.xml"
+			wsdd.server.config.file="server-config.wsdd"
+			wsdd.service.namespace="Plugin"
+			wsdd.output.path="src/" />
+
+		<property file="bnd.bnd" prefix="bnd." />
+
+		<echo file="bnd-${plugin.name}-wsdd.bnd">Bundle-SymbolicName: ${bnd.Bundle-SymbolicName}.wsdd
+Bundle-Name: ${bnd.Bundle-Name} WSDD descriptors
+Bundle-Version: ${bnd.Bundle-Version}
+Fragment-Host: ${bnd.Bundle-SymbolicName}
+Include-Resource: WEB-INF/=server-config.wsdd,classes;filter:=*.wsdd
+		</echo>
+
+		<bndexpand propertyfile="${sdk.dir}/common.bnd" />
+
+		<baseline-jar
+			bndRootFile="${sdk.dir}/common.bnd"
+			file="${basedir}/bnd-${plugin.name}-wsdd.bnd"
+			outputPath="${sdk.dir}/dist/${plugin.name}-${plugin.full.version}-wsdd-fragment.${plugin.packaging}"
+			sourcePath="${basedir}">
+			<classpath>
+				<pathelement location="${plugin.classes.dir}" />
+			</classpath>
+		</baseline-jar>
+
+		<delete file="${basedir}/bnd-${plugin.name}-wsdd.bnd" failonerror="false" />
+	</target>
+
 	<target name="jar">
 		<jar-macro
 			module.dir="${basedir}"

--- a/build-common-plugin.xml
+++ b/build-common-plugin.xml
@@ -336,6 +336,58 @@
 		<delete dir="${service.base.dir}/service-classes" />
 	</target>
 
+	<macrodef name="build-wsdd">
+		<attribute name="wsdd.classpath.property" />
+		<attribute name="wsdd.input.file" />
+		<attribute name="wsdd.server.config.file" />
+		<attribute name="wsdd.service.namespace" />
+		<attribute name="wsdd.output.path" />
+
+		<sequential>
+			<if>
+				<os family="windows" />
+				<then>
+					<classpath-to-jar
+						classpathref="@{wsdd.classpath.property}"
+						jarfile="build-wsdd-classpath.jar"
+					/>
+				</then>
+			</if>
+
+			<java
+				classname="com.liferay.portal.tools.WSDDBuilder"
+				classpathref="@{wsdd.classpath.property}"
+				fork="true"
+				maxmemory="256m"
+				newenvironment="true"
+				outputproperty="build-wsdd.output"
+			>
+				<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
+				<jvmarg value="-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.Log4JLogger" />
+				<arg value="wsdd.input.file=@{wsdd.input.file}" />
+				<arg value="wsdd.server.config.file=@{wsdd.server.config.file}" />
+				<arg value="wsdd.service.namespace=@{wsdd.service.namespace}" />
+				<arg value="wsdd.output.path=@{wsdd.output.path}" />
+			</java>
+
+			<if>
+				<os family="windows" />
+				<then>
+					<delete file="build-wsdd-classpath.jar" />
+				</then>
+			</if>
+
+			<echo>${build-wsdd.output}</echo>
+
+			<if>
+				<contains string="${build-wsdd.output}" substring="IOException" />
+				<then>
+					<fail>WSDD Builder generated exceptions.</fail>
+				</then>
+			</if>
+		</sequential>
+	</macrodef>
+
 	<target name="build-wsdd">
 		<loop-macrodef-or-target
 			module.dirs="${basedir}"
@@ -349,47 +401,11 @@
 			<pathelement location="docroot/WEB-INF/classes" />
 		</path>
 
-		<if>
-			<os family="windows" />
-			<then>
-				<classpath-to-jar
-					classpathref="wsdd.classpath"
-					jarfile="build-wsdd-classpath.jar"
-				/>
-			</then>
-		</if>
-
-		<java
-			classname="com.liferay.portal.tools.WSDDBuilder"
-			classpathref="wsdd.classpath"
-			fork="true"
-			maxmemory="256m"
-			newenvironment="true"
-			outputproperty="build-wsdd.output"
-		>
-			<jvmarg value="-Dexternal-properties=com/liferay/portal/tools/dependencies/portal-tools.properties" />
-			<jvmarg value="-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.Log4JLogger" />
-			<arg value="wsdd.input.file=docroot/WEB-INF/service.xml" />
-			<arg value="wsdd.server.config.file=docroot/WEB-INF/server-config.wsdd" />
-			<arg value="wsdd.service.namespace=Plugin" />
-			<arg value="wsdd.output.path=docroot/WEB-INF/src/" />
-		</java>
-
-		<if>
-			<os family="windows" />
-			<then>
-				<delete file="build-wsdd-classpath.jar" />
-			</then>
-		</if>
-
-		<echo>${build-wsdd.output}</echo>
-
-		<if>
-			<contains string="${build-wsdd.output}" substring="IOException" />
-			<then>
-				<fail>WSDD Builder generated exceptions.</fail>
-			</then>
-		</if>
+		<build-wsdd
+			wsdd.input.file="docroot/WEB-INF/service.xml"
+			wsdd.server.config.file="docroot/WEB-INF/server-config.wsdd"
+			wsdd.service.namespace="Plugin"
+			wsdd.output.path="docroot/WEB-INF/src/" />
 	</target>
 
 	<target name="build-wsdl">
@@ -813,7 +829,7 @@
 
 		<test-cmd
 			module.dir="${basedir}"
-			junit.forkmode="once" 
+			junit.forkmode="once"
 			test.class="${test.classes}"
 			test.type="integration"
 		/>

--- a/build-common.xml
+++ b/build-common.xml
@@ -396,6 +396,8 @@ Error-Prone was automatically installed. Please rerun your task.
 					</if>
 
 					<delete file="${module.auto.deploy.dir}/${plugin.name}.${plugin.packaging}" />
+					<delete file="${sdk.dir}/dist/${plugin.name}-${plugin.full.version}-wsdd-fragment.${plugin.packaging}" />
+					<delete file="${module.auto.deploy.dir}/${plugin.name}-wsdd-fragment.${plugin.packaging}" />
 				</then>
 			</if>
 		</sequential>
@@ -1298,6 +1300,15 @@ Please find a solution that does not require portal-impl.jar.
 								file="${plugin.file}"
 								tofile="${module.auto.deploy.dir}/${plugin.name}.${plugin.packaging}"
 							/>
+							<if>
+								<available file="${sdk.dir}/dist/${plugin.name}-${plugin.full.version}-wsdd-fragment.${plugin.packaging}" />
+								<then>
+									<copy 
+										file="${sdk.dir}/dist/${plugin.name}-${plugin.full.version}-wsdd-fragment.${plugin.packaging}" 
+										tofile="${module.auto.deploy.dir}/${plugin.name}-wsdd-fragment.${plugin.packaging}" 
+										failonerror="false" />
+								</then>
+							</if>
 						</then>
 					</if>
 				</else>


### PR DESCRIPTION
Hey Brian, 

this pull is to add support in the SDK to build the wsdd and package them into an optional fragment in order to support legacy axis web services in OSGi modules. 
A new pull is coming with an OSGi extender which registers these services under "/o" servlet context. 