### PR TITLE
LRQA-14421 Create multiroot-subant macrodef to avoid the property overri...

### DIFF
--- a/build-common-plugins.xml
+++ b/build-common-plugins.xml
@@ -64,18 +64,22 @@
 	</target>
 
 	<target name="setup-eclipse">
-		<subant target="setup-eclipse">
-			<multirootfileset basedirs="${plugins.includes.path}">
-				<include name="build.xml" />
-			</multirootfileset>
-		</subant>
+		<multiroot-subant
+			root.dir="${basedir}"
+			includes="${plugins.includes}"
+			excludes="${plugins.excludes}"
+			target="setup-eclipse"
+			build.file="build.xml"
+		/>
 	</target>
 
 	<target name="test-class-group">
-		<subant target="test-class-group">
-			<multirootfileset basedirs="${plugins.includes.path}">
-				<include name="build.xml" />
-			</multirootfileset>
-		</subant>
+		<multiroot-subant
+			root.dir="${basedir}"
+			includes="${plugins.includes}"
+			excludes="${plugins.excludes}"
+			target="test-class-group"
+			build.file="build.xml"
+		/>
 	</target>
 </project>

--- a/build-common.xml
+++ b/build-common.xml
@@ -2085,6 +2085,30 @@ Please find a solution that does not require portal-impl.jar.
 		</sequential>
 	</macrodef>
 
+	<macrodef name="multiroot-subant">
+		<attribute name="root.dir" />
+		<attribute name="includes" />
+		<attribute name="excludes" />
+		<attribute name="target" />
+		<attribute name="build.file" />
+
+		<sequential>
+			<path id="includes.path">
+				<dirset dir="@{root.dir}" excludes="@{excludes}" includes="@{includes}" />
+			</path>
+
+			<local name="includes.path" />
+
+			<pathconvert pathsep="," property="includes.path" refid="includes.path" targetos="unix" />
+
+			<subant target="@{target}">
+				<multirootfileset basedirs="${includes.path}">
+					<include name="@{build.file}" />
+				</multirootfileset>
+			</subant>
+		</sequential>
+	</macrodef>
+
 	<macrodef name="release">
 		<attribute name="module.dir" />
 


### PR DESCRIPTION
...ding issue (plugins.includes.path is defined in a lot places, and the only the first one takes effect during the test-class-group call, causing some modules are missed during processing)