### PR TITLE
LPS-55044

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -190,7 +190,7 @@ Error-Prone was automatically installed. Please rerun your task.
 
 		<sequential>
 			<fileset
-				dir="${basedir}"
+				dir="@{module.dir}"
 				id="soy.fileset"
 				includes="docroot/**/*.soy,src/META-INF/resources/**/*.soy"
 			/>
@@ -212,10 +212,10 @@ Error-Prone was automatically installed. Please rerun your task.
 								maxmemory="1024m"
 								newenvironment="true"
 							>
-								<arg value="--srcs" />
-								<arg value="@{soy.full.path}" />
 								<arg value="--outputPathFormat" />
 								<arg value="@{soy.full.path}.js" />
+								<arg value="--srcs" />
+								<arg value="@{soy.full.path}" />
 							</java>
 						</sequential>
 					</for>

--- a/build-common.xml
+++ b/build-common.xml
@@ -185,6 +185,45 @@ Error-Prone was automatically installed. Please rerun your task.
 		</sequential>
 	</macrodef>
 
+	<macrodef name="build-soy">
+		<attribute name="module.dir" />
+
+		<sequential>
+			<fileset
+				dir="${basedir}"
+				id="soy.fileset"
+				includes="docroot/**/*.soy,src/META-INF/resources/**/*.soy"
+			/>
+
+			<if>
+				<resourcecount count="0" when="gt" >
+					<fileset refid="soy.fileset" />
+				</resourcecount>
+				<then>
+					<for param="soy.full.path">
+						<path>
+							<fileset refid="soy.fileset" />
+						</path>
+						<sequential>
+							<java
+								classname="com.google.template.soy.SoyToJsSrcCompiler"
+								classpathref="plugin.classpath"
+								fork="true"
+								maxmemory="1024m"
+								newenvironment="true"
+							>
+								<arg value="--srcs" />
+								<arg value="@{soy.full.path}" />
+								<arg value="--outputPathFormat" />
+								<arg value="@{soy.full.path}.js" />
+							</java>
+						</sequential>
+					</for>
+				</then>
+			</if>
+		</sequential>
+	</macrodef>
+
 	<macrodef name="build-wsdl">
 		<attribute name="module.dir" />
 
@@ -2830,6 +2869,13 @@ for (String path : paths) {
 		<loop-macrodef-or-target
 			module.dirs="${plugins.includes.path}"
 			target.name="build-css"
+		/>
+	</target>
+
+	<target name="build-soy">
+		<loop-macrodef-or-target
+			module.dirs="${plugins.includes.path}"
+			target.name="build-soy"
 		/>
 	</target>
 


### PR DESCRIPTION
Hi Brian,

There are some cases we don't want to generate the soy.js files. So it would be better if we leave this task optional.

We're adding this to DDM modules because we want to be able to render the field template via JavaScript, but soy also have the API to render them on the back-end only, like we did on portal-template-soy module.

Regards,