### PR TITLE
 LRIS-15439 Update liferay-releng.properties

### DIFF
--- a/webs/screens-web/docroot/WEB-INF/liferay-releng.properties
+++ b/webs/screens-web/docroot/WEB-INF/liferay-releng.properties
@@ -1,4 +1,4 @@
-bundle=true
+bundle=false
 category=Utility
 demo-url=
 dependent-apps=


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-15825
Liferay screens is not a bundled plugin.
Liferay Screens is not present in master and ee-6.2.x