### PR TITLE
LPS-55635 Fix plugins compile issue

### DIFF
--- a/build-common-ivy.xml
+++ b/build-common-ivy.xml
@@ -113,6 +113,7 @@
 			<var name="mirrors.cache.artifact.dir" unset="true" />
 			<var name="mirrors.cache.artifact.file.name" unset="true" />
 			<var name="mirrors.cache.artifact.subdir" unset="true" />
+			<var name="mirrors.src" unset="true" />
 		</sequential>
 	</macrodef>
 


### PR DESCRIPTION
@brianchandotcom, 

Issue: 
There is currently a plugins compile issue where if the local mirrors cache and the local .ivy directory do not exist, then the compile will fail. Here are links to the failure: 
https://gist.github.com/kenjiheigel/c456d372f1c145ece944
https://test-2-1.liferay.com/job/test-portal-branch-upstream-plugins(ee-7.0.x)/1/console

Explanation:
This is because target will need to use the "mirrors-get" macrodef to download both the ivy*SNAPSHOT.jar as well as any additional files the plugins may need to compile.

I believe this began occurring because the target related to the ivy\*SNAPSHOT.jar was recently updated to use "mirrors-get" in https://github.com/liferay/liferay-plugins/commit/13717d17e98388e025260a2386ee737b1f25592b#diff-760d34d4ea37672fc5dbccc501e2d68dR448. Because of this, if the compile target downloads the ivy\*SNAPSHOT.jar (using "mirrors-get"), then the "mirrors.src" property will be set to the ivy url file, causing subsequent uses of "mirrors-get" to download that same file. 

This does not fail on the pull request tester, because we run "ant clean" before "ant compile". "ant clean" will actually download the ivy\*SNAPSHOT.jar, so it does not try to download the file when running other targets afterwards. It is affecting the plugins jobs on test-2 though, because we simply run "ant compile" after reseting the branch and using "git clean". 

Fix:
Unsetting the mirrors.src property in the macrodef fixes the issue. 

Let me know if you have any questions. Thank you. 

cc-ing: 
@brianchiu @CAustin582