### PR TITLE
LPS-54505 - fix property declaration typo

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1302,7 +1302,7 @@ Please find a solution that does not require portal-impl.jar.
 					<fileset dir="${module.framework.base.dir}/portal" includes="com.liferay.frontend.css.web*.jar" />
 				</resourcecount>
 				<then>
-					<property name="front.css.web.dir" value="${sdk.dir}/tmp/com.liferay.frontend.css.web" />
+					<property name="frontend.css.web.dir" value="${sdk.dir}/tmp/com.liferay.frontend.css.web" />
 
 					<mkdir dir="${frontend.css.web.dir}" />
 

--- a/build-common.xml
+++ b/build-common.xml
@@ -1458,6 +1458,8 @@ Please find a solution that does not require portal-impl.jar.
 					</if>
 				</else>
 			</if>
+
+			<delete dir="${frontend.css.web.dir}" />
 		</sequential>
 	</macrodef>
 


### PR DESCRIPTION
Hey Brian,

I noticed a typo in the property declaration, and also the tmp directory was being left behind so I am now deleting it.

Please let me know if there are any issues.

Thanks!