### PR TITLE
LPS-56948 Fix path for NodeJS on windows during build

### DIFF
--- a/build-common-node.xml
+++ b/build-common-node.xml
@@ -191,9 +191,19 @@ ${nodejs.url[osx64]}.
 				</then>
 			</if>
 
-			<exec dir="@{node.working.dir}" executable="${sdk.tools.dir}/node-v${nodejs.version}/bin/@{node.command}">
-				<arg line="@{node.command.args} @{node.args}" />
-			</exec>
+			<if>
+				<os family="windows" />
+				<then>
+					<exec dir="@{node.working.dir}" executable="${sdk.tools.dir}/node-v${nodejs.version}/@{node.command}.cmd">
+						<arg line="@{node.command.args} @{node.args}" />
+					</exec>
+				</then>
+				<else>
+					<exec dir="@{node.working.dir}" executable="${sdk.tools.dir}/node-v${nodejs.version}/bin/@{node.command}">
+						<arg line="@{node.command.args} @{node.args}" />
+					</exec>
+				</else>
+			</if>
 		</sequential>
 	</macrodef>
 


### PR DESCRIPTION
Hey Brian,

@ipeychev fix the node js downloading for unix, but the master build fails on current master on windows. The problem is that the nodejs distribution is different for windows and unix, and this pull is fixing that.

Thanks,

Máté