### PR TITLE
LPS-57148 Decouple transpile-js from config-modules-js

### DIFF
--- a/build-common-node.xml
+++ b/build-common-node.xml
@@ -226,12 +226,6 @@ ${nodejs.url[osx64]}.
 
 			<mkdir dir="@{module.dir}/.js-cache" />
 
-			<copy
-				file="@{module.dir}/bower.json"
-				overwrite="true"
-				tofile="@{module.dir}/.js-cache/bower.json"
-			/>
-
 			<mkdir dir="@{module.dir}/tmp/transpile" />
 
 			<copy todir="@{module.dir}/tmp/transpile">
@@ -250,11 +244,6 @@ ${nodejs.url[osx64]}.
 				node.module.version="${nodejs.modules.version[lfr-amd-loader]}"
 			/>
 
-			<download-node-module
-				node.module.name="lfr-module-config-generator"
-				node.module.version="${nodejs.modules.version[lfr-module-config-generator]}"
-			/>
-
 			<pathconvert pathsep=" " property="transpile.files" setonempty="false" refid="transpile.fileset" >
 				<map from="@{module.dir}/src/" to="" />
 			</pathconvert>
@@ -266,10 +255,23 @@ ${nodejs.url[osx64]}.
 			/>
 
 			<var name="transpile.files" unset="true" />
+		</sequential>
+	</macrodef>
+
+	<macrodef name="config-js-modules">
+		<attribute name="module.dir" />
+
+		<sequential>
+			<mkdir dir="@{module.dir}/.js-cache/META-INF/resources" />
+
+			<download-node-module
+				node.module.name="lfr-module-config-generator"
+				node.module.version="${nodejs.modules.version[lfr-module-config-generator]}"
+			/>
 
 			<node-execute
 				node.command="node"
-				node.command.args="${sdk.tools.dir}/node-v${nodejs.version}/node_modules/lfr-module-config-generator/bin/index.js -c '' -e '' -f /_/g,- -i true -l -m @{module.dir}/.js-cache/bower.json -o @{module.dir}/classes/META-INF/config.json -r @{module.dir}/.js-cache/META-INF/resources @{module.dir}/.js-cache"
+				node.command.args="${sdk.tools.dir}/node-v${nodejs.version}/node_modules/lfr-module-config-generator/bin/index.js -c '' -e '' -f /_/g,- -i true -m @{module.dir}/.js-cache/bower.json -o @{module.dir}/.js-cache/META-INF/config.json -r @{module.dir}/.js-cache/META-INF/resources @{module.dir}/.js-cache"
 				node.working.dir="${sdk.tools.dir}/node-v${nodejs.version}"
 			/>
 		</sequential>

--- a/build-common.xml
+++ b/build-common.xml
@@ -1984,6 +1984,36 @@ Please find a solution that does not require portal-impl.jar.
 										</then>
 									</if>
 
+									<if>
+										<available file="@{module.dir}/bower.json" />
+										<then>
+											<if>
+												<isset property="js.config.generator.fileset" />
+												<then>
+													<copy todir="@{module.dir}/.js-cache/META-INF/resources">
+														<resources refid="${js.config.generator.fileset}" />
+													</copy>
+
+													<var name="js.config.generator.fileset" unset="true" />
+												</then>
+											</if>
+
+											<copy
+												file="@{module.dir}/bower.json"
+												overwrite="true"
+												tofile="@{module.dir}/.js-cache/bower.json"
+											/>
+
+											<config-js-modules
+												module.dir="@{module.dir}"
+											/>
+										</then>
+									</if>
+
+									<copy todir="@{module.dir}/classes">
+										<fileset dir="@{module.dir}/.js-cache" erroronmissingdir="false" />
+									</copy>
+
 									<build-wsdl
 										module.dir="@{module.dir}"
 									/>


### PR DESCRIPTION
For reference, we'd want to use this from a module `build.xml` in portal like this:

https://github.com/jbalsas/liferay-portal/blob/57a500f218f6575c5863371942c912d0d6315b6e/modules/frontend/frontend-js-crystal/build.xml

In addition, we'll need to apply a similar pattern for the `transpile-js` macrodef and the `transpile.file.pattern` which has already proved to be insufficient. 

Do you think we could achieve this some other way?

Thanks!