### PR TITLE
LPS-57228 Notifications portlet is not showing on the dockbar

### DIFF
--- a/portlets/notifications-portlet/docroot/WEB-INF/liferay-display.xml
+++ b/portlets/notifications-portlet/docroot/WEB-INF/liferay-display.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<!DOCTYPE display PUBLIC "-//Liferay//DTD Display 6.2.0//EN" "http://www.liferay.com/dtd/liferay-display_6_2_0.dtd">
-
-<display>
-	<category name="category.social">
-		<portlet id="1" />
-	</category>
-</display>

--- a/portlets/notifications-portlet/docroot/WEB-INF/liferay-portlet.xml
+++ b/portlets/notifications-portlet/docroot/WEB-INF/liferay-portlet.xml
@@ -4,6 +4,8 @@
 <liferay-portlet-app>
 	<portlet>
 		<portlet-name>1</portlet-name>
+		<control-panel-entry-category>user.my_account</control-panel-entry-category>
+		<control-panel-entry-weight>2.0</control-panel-entry-weight>
 		<header-portlet-css>/notifications/css/main.css</header-portlet-css>
 		<footer-portlet-javascript>/notifications/js/main.js</footer-portlet-javascript>
 		<css-class-wrapper>notifications-portlet</css-class-wrapper>


### PR DESCRIPTION
This pull changes the behaviour of Notifications portlet. Before the notifications portlet could be added to a page and now we removed that possibility, so it won't longer be displayed to be added to a page.

Since we don't have dockbar anymore, we have included the Notifications portlet in the Product Menu (on the left side of the page). Inside "My Space" and "My Account" is where the notifications portlet will be displayed from now and on.

There's still some work to be done to show the number of pending notifications so the user doesn't need to open Notifications portlet to see them. That depends on this story that is not finished yet: https://issues.liferay.com/browse/LPS-57562

So, for now, I'll close this ticket and we'll assume that not displaying the number of notifications will be a limitation until this story gets merged (https://issues.liferay.com/browse/LPS-57562).