### PR TITLE
LPS-60600 When export the attachment, we should export reference Model. Because when import, we will firstly execute importReferenceStagedModels() in BaseStagedModelDataHandler.importStagedModel(). If the reference Model didn't be exported, it will cause some issues in the process of executing  importReferenceStagedModels method

### DIFF
--- a/portlets/knowledge-base-portlet/docroot/WEB-INF/src/com/liferay/knowledgebase/admin/lar/KBArticleStagedModelDataHandler.java
+++ b/portlets/knowledge-base-portlet/docroot/WEB-INF/src/com/liferay/knowledgebase/admin/lar/KBArticleStagedModelDataHandler.java
@@ -356,9 +356,9 @@ public class KBArticleStagedModelDataHandler
 
 			portletDataContext.addZipEntry(path, fileEntry.getContentStream());
 
-			portletDataContext.addReferenceElement(
-				kbArticle, kbArticleElement, fileEntry,
-				PortletDataContext.REFERENCE_TYPE_WEAK, false);
+			StagedModelDataHandlerUtil.exportReferenceStagedModel(
+				portletDataContext, kbArticle, fileEntry,
+				PortletDataContext.REFERENCE_TYPE_WEAK);
 		}
 	}
 


### PR DESCRIPTION
cc @juliocamarero, @matethurzo