### PR TITLE
LPS-60705 The software catalog does not exist any more. I've left the logic as listing all plugins in Sourceforge's download page.

### DIFF
--- a/portlets/release-tools-portlet/docroot/view.jsp
+++ b/portlets/release-tools-portlet/docroot/view.jsp
@@ -94,7 +94,7 @@ An example URL is: <em>http://sourceforge.net/project/showfiles.php?group_id=492
 	<br />
 
 	<div class="portlet-msg-info">
-		Below are a list of plugins that are on SourceForge's download page but not available for the Plugin Installer.
+		Below are a list of plugins that are on SourceForge's download page.
 	</div>
 
 	<%
@@ -107,20 +107,12 @@ An example URL is: <em>http://sourceforge.net/project/showfiles.php?group_id=492
 	while (matcher.find()) {
 		String fileName = matcher.group(1);
 
-		String directDownloadURL = "http://downloads.sourceforge.net/" + projectName + "/" + fileName;
-
-		try {
-			sfPlugins.add(fileName);
-
-			com.liferay.portlet.softwarecatalog.service.SCProductVersionLocalServiceUtil.getProductVersionByDirectDownloadURL(directDownloadURL);
-		}
-		catch (Exception e) {
+		sfPlugins.add(fileName);
 	%>
 
-			<%= fileName %><br />
+		<%= fileName %><br />
 
 	<%
-		}
 	}
 	%>
 


### PR DESCRIPTION
This is a preliminary pull, prior to the pull in the main repo, removing the references to the software catalog in one plugin that was using it (the plugin seems quite outdated btw)