### PR TITLE
LPS-62392 Call the process-ivy task after defining all tasks

### DIFF
--- a/build-common-ivy.xml
+++ b/build-common-ivy.xml
@@ -251,8 +251,6 @@
 		</sequential>
 	</macrodef>
 
-	<process-ivy />
-
 	<macrodef name="record-git-commit-snapshot">
 		<sequential>
 			<loadfile srcfile="maven.deploy.log" property="maven.deploy.log.content" />
@@ -712,6 +710,8 @@ module.snapshot.url=${cdn.sonatype.url}/com/liferay/${bnd.Bundle-SymbolicName}/$
 			</if>
 		</sequential>
 	</macrodef>
+
+	<process-ivy />
 
 	<target name="publish">
 		<ivy:settings file="${sdk.dir}/ivy-settings-publisher.xml" />


### PR DESCRIPTION
When I launch ant build-service, I get this error trace:

```java
BUILD FAILED
/Users/aelian/dev/portal7/plugins/webs/screens-web/build.xml:12: The following error occurred while executing this line:
/Users/aelian/dev/portal7/plugins/build-common-osgi-plugin.xml:5: The following error occurred while executing this line:
/Users/aelian/dev/portal7/plugins/build-common-plugin.xml:5: The following error occurred while executing this line:
/Users/aelian/dev/portal7/plugins/build-common.xml:57: The following error occurred while executing this line:
/Users/aelian/dev/portal7/plugins/build-common-ivy.xml:254: The following error occurred while executing this line:
/Users/aelian/dev/portal7/plugins/build-common-ivy.xml:161: The following error occurred while executing this line:
/Users/aelian/dev/portal7/plugins/build-common-ivy.xml:181: Problem: failed to create task or type set-module-properties
Cause: The name is undefined.
Action: Check the spelling.
Action: Check that any custom tasks/types have been declared.
Action: Check that any <presetdef>/<macrodef> declarations have taken place.
```

The ant script is registering some macros and then executing the process-ivy task that calls the macro set-module-properties . But it fails because it is defined later on that file.

The process-ivy task should be called after defining all tasks needed.