### PR TITLE
LPS-62392 Call the process-ivy task after defining all tasks

### DIFF
--- a/build-common-ivy.xml
+++ b/build-common-ivy.xml
@@ -251,8 +251,6 @@
 		</sequential>
 	</macrodef>
 
-	<process-ivy />
-
 	<macrodef name="record-git-commit-snapshot">
 		<sequential>
 			<loadfile srcfile="maven.deploy.log" property="maven.deploy.log.content" />
@@ -712,6 +710,8 @@ module.snapshot.url=${cdn.sonatype.url}/com/liferay/${bnd.Bundle-SymbolicName}/$
 			</if>
 		</sequential>
 	</macrodef>
+
+	<process-ivy />
 
 	<target name="publish">
 		<ivy:settings file="${sdk.dir}/ivy-settings-publisher.xml" />


### PR DESCRIPTION
Sorry to reopen but the issue isn't specific to Liferay Screens, it breaks (only when adding/removing a dependency) all the plugins that have a build.xml + ivy.xml + bnd.bnd, so currently these 2 ones:

* [modules-admin-portlet](https://github.com/liferay/liferay-plugins/tree/master/portlets/modules-admin-portlet)
* [ip-geocoder-portlet](https://github.com/liferay/liferay-plugins/tree/master/portlets/ip-geocoder-portlet)

The ant script that processes the ivy changes defines several macros and automatically calls the _process-ivy_ task. Right now it executes the call *before* defining the other macros.

The issue is fixed with just moving the call to execute that task to the end of the file (or before the publish target).

If it is left as is right now the set-module part can't work ever for any plugin that matches the if condition: bnd + ivy + build.xml (and should be eliminated if is not useful or commented)

I'm bad explaining things, sorry. And the call to process-ivy() is easy to miss between all those macro definitions.