### PR TITLE
LPS-64333 Include Jericho as an Ivy dependency

### DIFF
--- a/portlets/knowledge-base-portlet/docroot/WEB-INF/liferay-plugin-package.properties
+++ b/portlets/knowledge-base-portlet/docroot/WEB-INF/liferay-plugin-package.properties
@@ -13,7 +13,6 @@ liferay-versions=7.0.0+
 portal-dependency-jars=\
     commons-math.jar,\
     jdom.jar,\
-    jericho-html.jar,\
     jstl-api.jar,\
     jstl-impl.jar,\
     rome.jar

--- a/portlets/knowledge-base-portlet/ivy.xml
+++ b/portlets/knowledge-base-portlet/ivy.xml
@@ -14,5 +14,6 @@
 		<dependency name="com.liferay.journal.api" org="com.liferay" rev="1.0.0-SNAPSHOT" />
 		<dependency name="com.liferay.markdown.converter" org="com.liferay" rev="1.0.2" />
 		<dependency name="com.liferay.wiki.api" org="com.liferay" rev="1.0.0-SNAPSHOT" />
+		<dependency name="jericho-html" org="net.htmlparser.jericho" rev="3.1"/>
 	</dependencies>
 </ivy-module>


### PR DESCRIPTION
@sergiogonzalez No need to backport this to 6.2.x.