### PR TITLE
LPS-65492

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1057,6 +1057,16 @@ Error-Prone was automatically installed. Please rerun your task.
 										/>
 									</then>
 								</elseif>
+								<elseif>
+									<available file="@{module.dir}/../@{plugin.required.context}/docroot/WEB-INF/lib/@{plugin.required.context}-service.jar" />
+									<then>
+										<copy
+											file="@{module.dir}/../@{plugin.required.context}/docroot/WEB-INF/lib/@{plugin.required.context}-service.jar"
+											todir="@{module.dir}/docroot/WEB-INF/lib"
+											overwrite="true"
+										/>
+									</then>
+								</elseif>
 							</if>
 						</sequential>
 					</for>


### PR DESCRIPTION
Hi Brian!
I'm working to move `sync-admin-portlet` and `sync-web` to `modules/apps/sync`. `sync-admin-portlet` has `sync-web` in its `required-deployment-contexts`, so we need to be able to copy `sync-web-service.jar` to `sync-admin-portlet/docroot/WEB-INF/lib`.