### PR TITLE
pull-request-197

### DIFF
--- a/portlets/chat-portlet/docroot/WEB-INF/service/com/liferay/chat/util/comparator/BuddyComparator.java
+++ b/portlets/chat-portlet/docroot/WEB-INF/service/com/liferay/chat/util/comparator/BuddyComparator.java
@@ -34,18 +34,22 @@ public class BuddyComparator implements Comparator<Object[]> {
 	@Override
 	public int compare(Object[] buddy1, Object[] buddy2) {
 		long userId1 = 0;
-		if(buddy1[0] instanceof (Long)) {
-			userId1 = (Long) buddy1[0];
+
+		if(buddy1[0] instanceof Long) {
+			userId1 = (Long)buddy1[0];
 		}
+
 		String firstName1 = (String)buddy1[2];
 		String middleName1 = (String)buddy1[3];
 		String lastName1 = (String)buddy1[4];
 		boolean awake1 = (Boolean)buddy1[6];
 
 		long userId2 = 0;
+
 		if(buddy2[0] instanceof Long) {
 			userId2 = (Long)buddy2[0];
 		}
+
 		String firstName2 = (String)buddy2[2];
 		String middleName2 = (String)buddy2[3];
 		String lastName2 = (String)buddy2[4];

--- a/portlets/chat-portlet/docroot/WEB-INF/service/com/liferay/chat/util/comparator/BuddyComparator.java
+++ b/portlets/chat-portlet/docroot/WEB-INF/service/com/liferay/chat/util/comparator/BuddyComparator.java
@@ -33,13 +33,19 @@ public class BuddyComparator implements Comparator<Object[]> {
 
 	@Override
 	public int compare(Object[] buddy1, Object[] buddy2) {
-		long userId1 = (Long)buddy1[0];
+		long userId1 = 0;
+		if(buddy1[0] instanceof (Long)) {
+			userId1 = (Long) buddy1[0];
+		}
 		String firstName1 = (String)buddy1[2];
 		String middleName1 = (String)buddy1[3];
 		String lastName1 = (String)buddy1[4];
 		boolean awake1 = (Boolean)buddy1[6];
 
-		long userId2 = (Long)buddy2[0];
+		long userId2 = 0;
+		if(buddy2[0] instanceof Long) {
+			userId2 = (Long)buddy2[0];
+		}
 		String firstName2 = (String)buddy2[2];
 		String middleName2 = (String)buddy2[3];
 		String lastName2 = (String)buddy2[4];


### PR DESCRIPTION
Heya Brian,
This is a pull from the community (https://github.com/liferay/liferay-plugins/pull/197), with the description here:
> There are cases where JabberImpl use comparator to search and sort but assigned true to first index and not an id resulting in a stacktrace:

> The change will check the type of buddy[0] before assuming it is a Long

Let me know if you have any other questions.

Thanks Brian :)