### PR TITLE
LPS-71964 HotDeployException when deploying JA language hook

### DIFF
--- a/hooks/localization-ja-hook/docroot/WEB-INF/liferay-plugin-package.properties
+++ b/hooks/localization-ja-hook/docroot/WEB-INF/liferay-plugin-package.properties
@@ -9,3 +9,5 @@ name=Japanese Localization
 page-url=http://www.liferay.com
 short-description=
 tags=japanese, layout, localize
+
+Import-Package:com.liferay.portal.kernel.security.auth


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-71964

@brianchandotcom per @rotty3000 
"The issue is with this hook properties file:
https://github.com/liferay/liferay-plugins/blob/master/hooks/localization-ja-hook/docroot/WEB-INF/src/portal.properties#L1
It's loading a class from portal kernel, but there's no way for the WAB generator to figure that out, so the WAB needs to import the package"

ee-7.0.x sent here https://github.com/brianchandotcom/liferay-plugins-ee/pull/21471