### PR TITLE
LPS-79653 Portlet 3.0: Upgrade to the Portlet 3.0.0 API (cast to Port…

### DIFF
--- a/portlets/sample-service-builder-portlet/docroot/edit_foo.jsp
+++ b/portlets/sample-service-builder-portlet/docroot/edit_foo.jsp
@@ -28,7 +28,7 @@ if (fooId > 0) {
 }
 %>
 
-<aui:form action="<%= renderResponse.createActionURL() %>" method="post" name="fm">
+<aui:form action="<%= (PortletURL)renderResponse.createActionURL() %>" method="post" name="fm">
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= foo == null ? Constants.ADD : Constants.UPDATE %>" />
 	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 	<aui:input name="fooId" type="hidden" value="<%= fooId %>" />


### PR DESCRIPTION
…letURL due to Portlet 3.0 changes to the MimeResponse.createRenderURL() method signature return value type)